### PR TITLE
fix/keeping deleted items

### DIFF
--- a/app/src/main/java/com/chesire/malime/room/AnimeDao.kt
+++ b/app/src/main/java/com/chesire/malime/room/AnimeDao.kt
@@ -5,6 +5,7 @@ import android.arch.persistence.room.Delete
 import android.arch.persistence.room.Insert
 import android.arch.persistence.room.OnConflictStrategy
 import android.arch.persistence.room.Query
+import android.arch.persistence.room.Transaction
 import android.arch.persistence.room.Update
 import com.chesire.malime.models.Anime
 import io.reactivex.Flowable
@@ -25,4 +26,16 @@ interface AnimeDao {
 
     @Delete
     fun delete(anime: Anime)
+
+    @Delete
+    fun deleteAll(animes: List<Anime>)
+
+    @Transaction
+    fun freshInsert(animes: List<Anime>) {
+        clear()
+        insertAll(animes)
+    }
+
+    @Query("DELETE FROM anime")
+    fun clear()
 }

--- a/app/src/main/java/com/chesire/malime/room/MangaDao.kt
+++ b/app/src/main/java/com/chesire/malime/room/MangaDao.kt
@@ -5,6 +5,7 @@ import android.arch.persistence.room.Delete
 import android.arch.persistence.room.Insert
 import android.arch.persistence.room.OnConflictStrategy
 import android.arch.persistence.room.Query
+import android.arch.persistence.room.Transaction
 import android.arch.persistence.room.Update
 import com.chesire.malime.models.Manga
 import io.reactivex.Flowable
@@ -25,4 +26,13 @@ interface MangaDao {
 
     @Delete
     fun delete(manga: Manga)
+
+    @Transaction
+    fun freshInsert(mangas: List<Manga>) {
+        clear()
+        insertAll(mangas)
+    }
+
+    @Query("DELETE FROM manga")
+    fun clear()
 }

--- a/app/src/main/java/com/chesire/malime/util/PeriodicUpdateService.kt
+++ b/app/src/main/java/com/chesire/malime/util/PeriodicUpdateService.kt
@@ -68,7 +68,7 @@ class PeriodicUpdateService : JobService() {
 
         Completable
             .fromAction({
-                MalimeDatabase.getInstance(applicationContext).animeDao().insertAll(animes)
+                MalimeDatabase.getInstance(applicationContext).animeDao().freshInsert(animes)
                 jobFinished(params, false)
             })
             .subscribeOn(Schedulers.io())
@@ -80,7 +80,7 @@ class PeriodicUpdateService : JobService() {
 
         Completable
             .fromAction({
-                MalimeDatabase.getInstance(applicationContext).mangaDao().insertAll(mangas)
+                MalimeDatabase.getInstance(applicationContext).mangaDao().freshInsert(mangas)
                 jobFinished(params, false)
             })
             .subscribeOn(Schedulers.io())


### PR DESCRIPTION
fix(*): on the periodic update service, when getting a list of new items, clear the current table before adding them.

There is definitely a better way to do this, but for now this works and seems fairly fast. It works fast enough on my lists.