### PR TITLE
Fix/crash when switching view

### DIFF
--- a/app/src/main/java/com/chesire/malime/view/maldisplay/EmptyableRecyclerView.kt
+++ b/app/src/main/java/com/chesire/malime/view/maldisplay/EmptyableRecyclerView.kt
@@ -14,8 +14,7 @@ class EmptyableRecyclerView @JvmOverloads constructor(
     context: Context?,
     attrs: AttributeSet? = null,
     defStyle: Int = 0
-) :
-    RecyclerView(context, attrs, defStyle) {
+) : RecyclerView(context, attrs, defStyle) {
 
     private lateinit var emptyView: View
     private val observer: AdapterDataObserver = object : AdapterDataObserver() {

--- a/app/src/main/java/com/chesire/malime/view/maldisplay/MalDisplayFragment.kt
+++ b/app/src/main/java/com/chesire/malime/view/maldisplay/MalDisplayFragment.kt
@@ -63,22 +63,21 @@ class MalDisplayFragment : Fragment() {
                 )
             )
             .get(MalDisplayViewModel::class.java)
-
-        viewAdapter = MalDisplayViewAdapter(viewModel, SharedPref(requireContext()))
-        viewModel.apply {
-            series.observe(this@MalDisplayFragment,
-                Observer {
-                    if (it != null) {
-                        viewAdapter.addAll(it.filter { it.type == type })
-                    }
-                })
-            updateAllStatus.observe(this@MalDisplayFragment,
-                Observer {
-                    if (it != null) {
-                        onUpdateAllStatusChange(it)
-                    }
-                })
-        }
+            .apply {
+                series.observe(this@MalDisplayFragment,
+                    Observer {
+                        if (it != null) {
+                            // Check for null here to be safe, as we initialize the adapter below
+                            viewAdapter?.addAll(it.filter { it.type == type })
+                        }
+                    })
+                updateAllStatus.observe(this@MalDisplayFragment,
+                    Observer {
+                        if (it != null) {
+                            onUpdateAllStatusChange(it)
+                        }
+                    })
+            }
     }
 
     override fun onCreateView(
@@ -86,6 +85,8 @@ class MalDisplayFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        viewAdapter = MalDisplayViewAdapter(viewModel, SharedPref(requireContext()))
+
         return DataBindingUtil.inflate<FragmentMaldisplayBinding>(
             inflater,
             R.layout.fragment_maldisplay,


### PR DESCRIPTION
Initialize the adapter in onCreateView instead of onCreate, this stops it crashing as it tries to set the adapter.