### PR TITLE
Fix/items loaded incorrectly

### DIFF
--- a/app/src/main/java/com/chesire/malime/util/updateservice/PeriodicUpdateService.kt
+++ b/app/src/main/java/com/chesire/malime/util/updateservice/PeriodicUpdateService.kt
@@ -36,7 +36,7 @@ class PeriodicUpdateService : JobService() {
 
     private fun getLatestLibrary(params: JobParameters?, library: Library) {
         library.updateLibraryFromApi()
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.computation())
             .subscribe({
                 Timber.d("Periodic update has received new library")
                 library.insertIntoLocalLibrary(it)

--- a/malime.kitsu/src/main/java/com/chesire/malime/kitsu/api/KitsuApi.kt
+++ b/malime.kitsu/src/main/java/com/chesire/malime/kitsu/api/KitsuApi.kt
@@ -60,8 +60,13 @@ class KitsuApi(
         return kitsuService.getUser()
     }
 
-    fun getUserLibrary(userId: Int, offset: Int): Call<LibraryResponse> {
-        return kitsuService.getUserLibrary(userId, offset)
+    fun getUserLibrary(userId: Int, offset: Int, type: ItemType): Call<LibraryResponse> {
+        // Ideally wanted to keep the api without logic, but this is nicer than in the manager
+        return if (type == ItemType.Anime) {
+            kitsuService.getUserAnime(userId, offset)
+        } else {
+            kitsuService.getUserManga(userId, offset)
+        }
     }
 
     fun search(title: String, type: ItemType): Call<LibraryResponse> {

--- a/malime.kitsu/src/main/java/com/chesire/malime/kitsu/api/KitsuService.kt
+++ b/malime.kitsu/src/main/java/com/chesire/malime/kitsu/api/KitsuService.kt
@@ -32,18 +32,50 @@ interface KitsuService {
     @GET("api/edge/users?fields[users]=id&filter[self]=true")
     fun getUser(): Call<LibraryResponse>
 
+    @Deprecated("Use the getUserAnime and getUserManga")
     @GET(
         "api/edge/users/{userId}/library-entries" +
                 "?include=anime,manga" +
                 "&fields[libraryEntries]=status,progress,anime,manga,startedAt,finishedAt" +
                 "&fields[anime]=slug,canonicalTitle,status,subtype,posterImage,coverImage,episodeCount,nsfw" +
                 "&fields[manga]=slug,canonicalTitle,status,subtype,posterImage,chapterCount" +
-                "&sort=anime.titles.canonical"
+                "&filter[kind]=manga" +
+                "&sort=manga.titles.canonical"
     )
     fun getUserLibrary(
         @Path("userId") userId: Int,
         @Query("page[offset]") offset: Int,
-        @Query("page[limit]") limit: Int = 500 // might want to reduce to say 100
+        @Query("page[limit]") limit: Int = 200
+    ): Call<LibraryResponse>
+
+    // if this limit is changed, then the kitsuManager#getUserEntriesForType offset should be changed to match
+    @GET(
+        "api/edge/users/{userId}/library-entries" +
+                "?include=anime" +
+                "&fields[libraryEntries]=status,progress,anime,startedAt,finishedAt" +
+                "&fields[anime]=slug,canonicalTitle,status,subtype,posterImage,coverImage,episodeCount,nsfw" +
+                "&filter[kind]=anime" +
+                "&sort=anime.titles.canonical"
+    )
+    fun getUserAnime(
+        @Path("userId") userId: Int,
+        @Query("page[offset]") offset: Int,
+        @Query("page[limit]") limit: Int = 200
+    ): Call<LibraryResponse>
+
+    // if this limit is changed, then the kitsuManager#getUserEntriesForType offset should be changed to match
+    @GET(
+        "api/edge/users/{userId}/library-entries" +
+                "?include=manga" +
+                "&fields[libraryEntries]=status,progress,manga,startedAt,finishedAt" +
+                "&fields[manga]=slug,canonicalTitle,status,subtype,posterImage,chapterCount" +
+                "&filter[kind]=manga" +
+                "&sort=manga.titles.canonical"
+    )
+    fun getUserManga(
+        @Path("userId") userId: Int,
+        @Query("page[offset]") offset: Int,
+        @Query("page[limit]") limit: Int = 200
     ): Call<LibraryResponse>
 
     // Search is limited to 20 items at once, might want to do the above if more are required

--- a/malime.kitsu/src/main/java/com/chesire/malime/kitsu/api/KitsuService.kt
+++ b/malime.kitsu/src/main/java/com/chesire/malime/kitsu/api/KitsuService.kt
@@ -37,7 +37,8 @@ interface KitsuService {
                 "?include=anime,manga" +
                 "&fields[libraryEntries]=status,progress,anime,manga,startedAt,finishedAt" +
                 "&fields[anime]=slug,canonicalTitle,status,subtype,posterImage,coverImage,episodeCount,nsfw" +
-                "&fields[manga]=slug,canonicalTitle,status,subtype,posterImage,chapterCount"
+                "&fields[manga]=slug,canonicalTitle,status,subtype,posterImage,chapterCount" +
+                "&sort=anime.titles.canonical"
     )
     fun getUserLibrary(
         @Path("userId") userId: Int,


### PR DESCRIPTION
It looks like relying on the Kitsu index didn't work, as sometimes the items would return out of order.
This PR enforces sort on the items that are pulled down, this looks to be how its done in the offical Kitsu app as well.