### PR TITLE
fix(logout): stop possible crash when logging out

### DIFF
--- a/malime.core/src/main/java/com/chesire/malime/core/repositories/Authorization.kt
+++ b/malime.core/src/main/java/com/chesire/malime/core/repositories/Authorization.kt
@@ -14,8 +14,8 @@ class Authorization(private val authorizers: Map<SupportedService, Authorizer<*>
     }
 
     fun logoutAll() {
-        authorizers.forEach { _, value ->
-            value.clear()
+        SupportedService.values().forEach {
+            authorizers[it]?.clear()
         }
     }
 }


### PR DESCRIPTION
It was experienced on API21 on some phones, that attempting to logout would crash the application. ProGuard was removing some of the required files. It looks like changing from using the `.forEach` on the authorizers to using it based on all possible SupportedService works