### PR TITLE
Feat/add licenses page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'io.fabric'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -79,6 +80,8 @@ dependencies {
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
+
+    implementation 'com.google.android.gms:play-services-oss-licenses:16.0.0'
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.1'
     debugImplementation 'com.squareup.leakcanary:leakcanary-support-fragment:1.6.1'

--- a/app/src/main/java/com/chesire/malime/view/preferences/PrefFragment.kt
+++ b/app/src/main/java/com/chesire/malime/view/preferences/PrefFragment.kt
@@ -1,16 +1,26 @@
 package com.chesire.malime.view.preferences
 
+import android.content.Intent
 import android.os.Bundle
 import android.support.v7.preference.PreferenceFragmentCompat
 import com.chesire.malime.R
 import com.chesire.malime.util.SHARED_PREF_FILE
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 
 class PrefFragment : PreferenceFragmentCompat() {
-
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         val manager = preferenceManager
         manager.sharedPreferencesName = SHARED_PREF_FILE
         addPreferencesFromResource(R.xml.preferences)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        findPreference(getString(R.string.key_view_licenses)).setOnPreferenceClickListener {
+            startActivity(Intent(requireActivity(), OssLicensesMenuActivity::class.java))
+            true
+        }
     }
 
     companion object {

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="key_view_licenses">viewLicenses</string>
+</resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="key_view_licenses" translatable="false">viewLicenses</string>
+</resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="key_view_licenses" translatable="false">viewLicenses</string>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
 
     <string name="preference_title_crash_reporting">Crash Reporting</string>
     <string name="preference_summary_crash_reporting">Allow anonymous crash reporting?</string>
+    <string name="preference_title_view_licenses">View License Information</string>
+    <string name="preference_summary_view_licenses">View license information of open source libraries used</string>
 
     <string name="service_selection_header">Select your primary tracking service</string>
     <string name="service_selection_mal">MyAnimeList</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -7,4 +7,9 @@
         android:summary="@string/preference_summary_crash_reporting"
         android:title="@string/preference_title_crash_reporting" />
 
+    <Preference
+        android:key="@string/key_view_licenses"
+        android:summary="@string/preference_summary_view_licenses"
+        android:title="@string/preference_title_view_licenses" />
+
 </android.support.v7.preference.PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.google.android.gms:oss-licenses-plugin:0.9.3'
         classpath 'com.google.gms:google-services:3.2.0'
         classpath 'io.fabric.tools:gradle:1.25.1'
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"


### PR DESCRIPTION
Add a licenses page that can be viewed from the preferences screen. The Google library https://developers.google.com/android/guides/opensource has been used for this.