### PR TITLE
refactor(preferences): use resources for all preference keys

### DIFF
--- a/app/src/main/java/com/chesire/malime/util/SharedPref.kt
+++ b/app/src/main/java/com/chesire/malime/util/SharedPref.kt
@@ -3,43 +3,43 @@ package com.chesire.malime.util
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
+import com.chesire.malime.R
 import com.chesire.malime.core.flags.SupportedService
 import com.chesire.malime.view.preferences.SortOption
 import javax.inject.Inject
 
-private const val PREF_PRIMARY_SERVICE = "primaryService"
-private const val PREF_ALLOW_CRASH_REPORTING = "allowCrashReporting"
-private const val PREF_FILTER_LENGTH = "animeFilterLength"
-private const val PREF_SERIES_UPDATE_SCHEDULER_ENABLED = "seriesUpdateSchedulerEnabled"
-private const val PREF_REFRESH_TOKEN_SCHEDULER_ENABLED = "refreshTokenSchedulerEnabled"
-const val PREF_FILTER = "filter"
-const val PREF_SORT = "sort"
-const val SHARED_PREF_FILE = "malime_shared_pref"
-
 @Suppress("TooManyFunctions")
 class SharedPref @Inject constructor(context: Context) {
+    private val allowCrashReporting = context.getString(R.string.key_allow_crash_reporting)
+    private val updateSchedulerEnabled = context.getString(R.string.key_update_scheduler_enabled)
+    private val refreshSchedulerEnabled = context.getString(R.string.key_refresh_scheduler_enabled)
+    private val animeFilterLength = context.getString(R.string.key_anime_filter_length)
+    private val primaryService = context.getString(R.string.key_primary_service)
+    private val filter = context.getString(R.string.key_filter)
+    private val sort = context.getString(R.string.key_sort)
+
     private val sharedPreferences =
-        context.getSharedPreferences(SHARED_PREF_FILE, Context.MODE_PRIVATE)
+        context.getSharedPreferences(
+            context.getString(R.string.key_shared_pref_file_name),
+            Context.MODE_PRIVATE
+        )
 
     fun getPrimaryService() =
         SupportedService.valueOf(
-            sharedPreferences.getString(
-                PREF_PRIMARY_SERVICE,
-                SupportedService.Unknown.name
-            )
+            sharedPreferences.getString(primaryService, SupportedService.Unknown.name)
         )
 
     @SuppressLint("ApplySharedPref")
     fun putPrimaryService(service: SupportedService): SharedPref {
         // Push this into shared preferences straight away, instead of waiting in the background
         sharedPreferences.edit()
-            .putString(PREF_PRIMARY_SERVICE, service.name)
+            .putString(primaryService, service.name)
             .commit()
 
         return this
     }
 
-    fun getAllowCrashReporting() = sharedPreferences.getBoolean(PREF_ALLOW_CRASH_REPORTING, true)
+    fun getAllowCrashReporting() = sharedPreferences.getBoolean(allowCrashReporting, true)
 
     fun getFilter(): BooleanArray {
         if (!hasStoredFilter()) {
@@ -48,10 +48,10 @@ class SharedPref @Inject constructor(context: Context) {
             return defaultFilter
         }
 
-        val filterLength = sharedPreferences.getInt(PREF_FILTER_LENGTH, 0)
+        val filterLength = sharedPreferences.getInt(animeFilterLength, 0)
         val returnArray = BooleanArray(filterLength)
         for (i in 0 until filterLength) {
-            returnArray[i] = sharedPreferences.getBoolean(PREF_FILTER + i, false)
+            returnArray[i] = sharedPreferences.getBoolean(filter + i, false)
         }
 
         return returnArray
@@ -59,9 +59,9 @@ class SharedPref @Inject constructor(context: Context) {
 
     fun setFilter(input: BooleanArray): SharedPref {
         val editor = sharedPreferences.edit()
-        editor.putInt(PREF_FILTER_LENGTH, input.count())
+        editor.putInt(animeFilterLength, input.count())
         for (i in input.indices) {
-            editor.putBoolean(PREF_FILTER + i, input[i])
+            editor.putBoolean(filter + i, input[i])
         }
         editor.apply()
 
@@ -71,7 +71,7 @@ class SharedPref @Inject constructor(context: Context) {
     fun getSortOption(): SortOption {
         return SortOption.getOptionFor(
             sharedPreferences.getInt(
-                PREF_SORT,
+                sort,
                 SortOption.Title.id
             )
         )
@@ -79,29 +79,29 @@ class SharedPref @Inject constructor(context: Context) {
 
     fun setSortOption(sortOption: SortOption): SharedPref {
         sharedPreferences.edit()
-            .putInt(PREF_SORT, sortOption.id)
+            .putInt(sort, sortOption.id)
             .apply()
 
         return this
     }
 
     fun getSeriesUpdateSchedulerEnabled() =
-        sharedPreferences.getBoolean(PREF_SERIES_UPDATE_SCHEDULER_ENABLED, false)
+        sharedPreferences.getBoolean(updateSchedulerEnabled, false)
 
     fun setSeriesUpdateSchedulerEnabled(state: Boolean): SharedPref {
         sharedPreferences.edit()
-            .putBoolean(PREF_SERIES_UPDATE_SCHEDULER_ENABLED, state)
+            .putBoolean(updateSchedulerEnabled, state)
             .apply()
 
         return this
     }
 
     fun getRefreshTokenSchedulerEnabled() =
-        sharedPreferences.getBoolean(PREF_REFRESH_TOKEN_SCHEDULER_ENABLED, false)
+        sharedPreferences.getBoolean(refreshSchedulerEnabled, false)
 
     fun setRefreshTokenSchedulerEnabled(state: Boolean): SharedPref {
         sharedPreferences.edit()
-            .putBoolean(PREF_REFRESH_TOKEN_SCHEDULER_ENABLED, state)
+            .putBoolean(refreshSchedulerEnabled, state)
             .apply()
 
         return this
@@ -116,13 +116,13 @@ class SharedPref @Inject constructor(context: Context) {
     }
 
     private fun hasStoredFilter(): Boolean {
-        if (!sharedPreferences.contains(PREF_FILTER_LENGTH)) {
+        if (!sharedPreferences.contains(animeFilterLength)) {
             return false
         }
 
-        val filterLength = sharedPreferences.getInt(PREF_FILTER_LENGTH, 0)
+        val filterLength = sharedPreferences.getInt(animeFilterLength, 0)
         for (i in 0 until filterLength) {
-            if (!sharedPreferences.contains(PREF_FILTER + i)) {
+            if (!sharedPreferences.contains(filter + i)) {
                 return false
             }
         }

--- a/app/src/main/java/com/chesire/malime/view/maldisplay/MalDisplayFragment.kt
+++ b/app/src/main/java/com/chesire/malime/view/maldisplay/MalDisplayFragment.kt
@@ -108,7 +108,7 @@ class MalDisplayFragment : Fragment(), Injectable, ModelInteractionListener {
                     })
             }
 
-        viewAdapter = MalDisplayViewAdapter(this, sharedPref)
+        viewAdapter = MalDisplayViewAdapter(requireContext(), this, sharedPref)
         recyclerView.adapter = viewAdapter
         binding.vm = viewModel
     }

--- a/app/src/main/java/com/chesire/malime/view/maldisplay/MalDisplayViewAdapter.kt
+++ b/app/src/main/java/com/chesire/malime/view/maldisplay/MalDisplayViewAdapter.kt
@@ -1,6 +1,7 @@
 package com.chesire.malime.view.maldisplay
 
 import android.app.AlertDialog
+import android.content.Context
 import android.content.SharedPreferences
 import android.databinding.ViewDataBinding
 import android.support.design.widget.Snackbar
@@ -20,8 +21,6 @@ import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.MalimeModel
 import com.chesire.malime.databinding.ItemMalmodelBinding
 import com.chesire.malime.util.GlideApp
-import com.chesire.malime.util.PREF_FILTER
-import com.chesire.malime.util.PREF_SORT
 import com.chesire.malime.util.SharedPref
 import com.chesire.malime.util.extension.getString
 import com.chesire.malime.view.preferences.SortOption
@@ -34,10 +33,13 @@ import timber.log.Timber
 import java.util.Locale
 
 class MalDisplayViewAdapter(
+    context: Context,
     private val listener: ModelInteractionListener,
     private val sharedPref: SharedPref
 ) : RecyclerView.Adapter<MalDisplayViewAdapter.ViewHolder>(), Filterable,
     SharedPreferences.OnSharedPreferenceChangeListener {
+    private val sortPref = context.getString(R.string.key_sort)
+    private val filterPref = context.getString(R.string.key_filter)
 
     private val items = ArrayList<MalimeModel>()
     private val filteredItems = ArrayList<MalimeModel>()
@@ -73,7 +75,7 @@ class MalDisplayViewAdapter(
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         key?.let {
-            if (it.contains(PREF_SORT) || it.contains(PREF_FILTER)) {
+            if (it.contains(sortPref) || it.contains(filterPref)) {
                 filter.filter("")
             }
         }

--- a/app/src/main/java/com/chesire/malime/view/preferences/PrefFragment.kt
+++ b/app/src/main/java/com/chesire/malime/view/preferences/PrefFragment.kt
@@ -4,13 +4,12 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.preference.PreferenceFragmentCompat
 import com.chesire.malime.R
-import com.chesire.malime.util.SHARED_PREF_FILE
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 
 class PrefFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        val manager = preferenceManager
-        manager.sharedPreferencesName = SHARED_PREF_FILE
+        preferenceManager.sharedPreferencesName =
+                requireContext().getString(R.string.key_shared_pref_file_name)
         addPreferencesFromResource(R.xml.preferences)
     }
 

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="key_shared_pref_file_name">malime_shared_pref</string>
+
     <string name="key_view_licenses">viewLicenses</string>
+    <string name="key_allow_crash_reporting">allowCrashReporting</string>
+    <string name="key_update_scheduler_enabled">seriesUpdateSchedulerEnabled</string>
+    <string name="key_refresh_scheduler_enabled">refreshTokenSchedulerEnabled</string>
+    <string name="key_anime_filter_length">animeFilterLength</string>
+    <string name="key_primary_service">primaryService</string>
+    <string name="key_filter">filter</string>
+    <string name="key_sort">sort</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,7 +3,7 @@
 
     <android.support.v7.preference.CheckBoxPreference
         android:defaultValue="true"
-        android:key="allowCrashReporting"
+        android:key="@string/key_allow_crash_reporting"
         android:summary="@string/preference_summary_crash_reporting"
         android:title="@string/preference_title_crash_reporting" />
 


### PR DESCRIPTION
Move all of the shared preference keys into a resource file, this keeps them in a consistent location to access.