### PR TITLE
chore: add config file for codecov to ignore dagger

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+    - "app/src/main/java/com/chesire/malime/injection/*"
+    - "app/src/main/java/com/chesire/malime/injection/**/*"
+	


### PR DESCRIPTION
Adds config file to ignore the dagger modules in code coverage