### PR TITLE
Mal 37/add code coverage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: 'dokka.gradle'
+apply from: 'jacoco.gradle'
 apply from: 'ktlint.gradle'
 
 android {
@@ -40,6 +41,7 @@ android {
             applicationIdSuffix = ".debug"
             versionNameSuffix '-DEBUG'
             resValue "string", "app_name", "@string/app_name_debug"
+            testCoverageEnabled true
         }
     }
     dataBinding {

--- a/app/jacoco.gradle
+++ b/app/jacoco.gradle
@@ -1,0 +1,43 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "$jacoco_version"
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+task jacocoTestReport(
+        type: JacocoReport,
+        group: 'verification',
+        dependsOn: ['testDebugUnitTest']
+        //dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']
+) {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def coverageExcludes = ['**/R.class',
+                            '**/R$*.class',
+                            '**/BuildConfig.*',
+                            '**/Manifest*.*',
+                            '**/*Test*.*',
+                            '**/*$$ViewBinder*.*',
+                            '**/inject/*',
+                            '**/*$InjectAdapter.*',
+                            '**/Dagger*.*',
+                            '**/*_Provide*Factory.*',
+                            '**/*_Member*Injector.*',
+                            '**/*_Factory.*',
+                            'android/**/*.*']
+    def debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: coverageExcludes)
+    def mainSrc = "$project.projectDir/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+    ])
+}

--- a/app/jacoco.gradle
+++ b/app/jacoco.gradle
@@ -12,7 +12,6 @@ task jacocoTestReport(
         type: JacocoReport,
         group: 'verification',
         dependsOn: ['testDebugUnitTest']
-        //dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']
 ) {
     reports {
         xml.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext.dagger_version = '2.17'
     ext.dokka_version = '0.9.16'
     ext.glide_version = "4.8.0"
+    ext.jacoco_version = '0.8.2'
     ext.kotlin_version = '1.2.51'
     ext.rxandroid_version = '2.0.2'
     ext.rxjava_version = '2.2.0'
@@ -15,6 +16,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.9.3'
         classpath 'com.google.gms:google-services:3.2.0'
+        classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/malime.core/build.gradle
+++ b/malime.core/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: '../app/dokka.gradle'
+apply from: '../app/jacoco.gradle'
 apply from: '../app/ktlint.gradle'
 
 android {

--- a/malime.kitsu/build.gradle
+++ b/malime.kitsu/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: '../app/dokka.gradle'
+apply from: '../app/jacoco.gradle'
 apply from: '../app/ktlint.gradle'
 
 android {

--- a/malime.mal/build.gradle
+++ b/malime.mal/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: '../app/dokka.gradle'
+apply from: '../app/jacoco.gradle'
 apply from: '../app/ktlint.gradle'
 
 android {


### PR DESCRIPTION
Generate code coverage so it can be pushed up to Codecov.

Currently the code coverage generated only takes into account unit tests, it is missing for UI tests.