### PR TITLE
chore: add slack code coverage reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,13 @@
 ignore:
     - "app/src/main/java/com/chesire/malime/injection/*"
     - "app/src/main/java/com/chesire/malime/injection/**/*"
-	
+coverage:
+  notify:
+    slack:
+      default:
+        secret: zPZxz/iaHgny+6G9TKg7XAdX4NwGnfpDXsdKo1Sm7rIAB9Pejzz1LlPvhSlw6DApExNwwl4ZCY/C8tiqd6jYjclPtISNa+cx7FXm6sTsijMmkHAMKz3GLV8hqWhyuJDHr2G8ZQ01GQGubSYtaWrnBoUwqQSBzKiLSEel2Yumojs=
+        threshold: 1%
+			  only_pulls: false
+        branches: null
+        flags: null
+				paths: null


### PR DESCRIPTION
Adds Code coverage reporting to Slack. Uses a secret token generated on Codecov