### PR TITLE
chore: add storage permission to debug builds

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.chesire.malime">
+
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+</manifest>

--- a/app2/src/debug/AndroidManifest.xml
+++ b/app2/src/debug/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.chesire.malime">
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+</manifest>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,9 @@
 ignore:
+	- "app/src/*"
 	- "app/src/**/*"
+	- "malime.core/*"
 	- "malime.core/**/*"
+	- "malime.kitsu/*"
 	- "malime.kitsu/**/*"
     - "app2/src/main/java/com/chesire/malime/injection/*"
     - "app2/src/main/java/com/chesire/malime/injection/**/*"


### PR DESCRIPTION
Add the storage permission to debug builds so that when code coverage is generated it can save it to the device.