### PR TITLE
refactor: switch to using viewmodelscope

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.0.1'
     implementation 'androidx.fragment:fragment-ktx:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0-alpha04'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.1.0-alpha02'
     implementation 'androidx.navigation:navigation-ui-ktx:2.1.0-alpha02'
     implementation 'androidx.room:room-runtime:2.1.0-alpha04'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,6 +99,7 @@ dependencies {
     testImplementation 'androidx.arch.core:core-testing:2.0.0'
     testImplementation 'io.mockk:mockk:1.9.3'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.1.1'
 
     androidTestImplementation 'androidx.arch.core:core-testing:2.0.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'

--- a/app/src/main/java/com/chesire/malime/flow/login/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/login/details/DetailsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.chesire.malime.IOContext
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.api.AuthApi
 import com.chesire.malime.repo.UserRepository
@@ -12,7 +11,6 @@ import com.hadilq.liveevent.LiveEvent
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
 
 class DetailsViewModel @Inject constructor(
     private val auth: AuthApi,

--- a/app/src/main/java/com/chesire/malime/flow/login/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/login/details/DetailsViewModel.kt
@@ -3,13 +3,12 @@ package com.chesire.malime.flow.login.details
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.chesire.malime.IOContext
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.api.AuthApi
 import com.chesire.malime.repo.UserRepository
 import com.hadilq.liveevent.LiveEvent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -17,18 +16,15 @@ import kotlin.coroutines.CoroutineContext
 
 class DetailsViewModel @Inject constructor(
     private val auth: AuthApi,
-    private val user: UserRepository,
-    @IOContext private val ioContext: CoroutineContext
+    private val user: UserRepository
 ) : ViewModel() {
-    private val job = Job()
-    private val ioScope = CoroutineScope(job + ioContext)
     private val _loginStatus = LiveEvent<LoginStatus>()
     val username = MutableLiveData<String>()
     val password = MutableLiveData<String>()
     val loginStatus: LiveData<LoginStatus>
         get() = _loginStatus
 
-    fun login() = ioScope.launch {
+    fun login() = viewModelScope.launch {
         if (!validParams()) {
             return@launch
         }
@@ -69,10 +65,5 @@ class DetailsViewModel @Inject constructor(
                 _loginStatus.postValue(LoginStatus.Error)
             }
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        job.cancel()
     }
 }

--- a/app/src/main/java/com/chesire/malime/flow/login/syncing/SyncingViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/login/syncing/SyncingViewModel.kt
@@ -5,17 +5,13 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.AsyncState
-import com.chesire.malime.IOContext
 import com.chesire.malime.core.Resource
 import com.chesire.malime.extensions.postError
 import com.chesire.malime.extensions.postLoading
 import com.chesire.malime.extensions.postSuccess
 import com.chesire.malime.repo.SeriesRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
 
 class SyncingViewModel @Inject constructor(
     private val seriesRepo: SeriesRepository

--- a/app/src/main/java/com/chesire/malime/flow/login/syncing/SyncingViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/login/syncing/SyncingViewModel.kt
@@ -3,6 +3,7 @@ package com.chesire.malime.flow.login.syncing
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.chesire.malime.AsyncState
 import com.chesire.malime.IOContext
 import com.chesire.malime.core.Resource
@@ -17,16 +18,13 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 class SyncingViewModel @Inject constructor(
-    private val seriesRepo: SeriesRepository,
-    @IOContext private val ioContext: CoroutineContext
+    private val seriesRepo: SeriesRepository
 ) : ViewModel() {
-    private val job = Job()
-    private val ioScope = CoroutineScope(job + ioContext)
     private val _syncStatus = MutableLiveData<AsyncState<Any, Any>>()
     val syncStatus: LiveData<AsyncState<Any, Any>>
         get() = _syncStatus
 
-    fun syncLatestData() = ioScope.launch {
+    fun syncLatestData() = viewModelScope.launch {
         _syncStatus.postLoading()
 
         val syncCommands = listOf(
@@ -39,10 +37,5 @@ class SyncingViewModel @Inject constructor(
         } else {
             _syncStatus.postSuccess(Any())
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        job.cancel()
     }
 }

--- a/app/src/main/java/com/chesire/malime/flow/series/list/anime/AnimeViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/anime/AnimeViewModel.kt
@@ -2,33 +2,19 @@ package com.chesire.malime.flow.series.list.anime
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import com.chesire.malime.IOContext
+import androidx.lifecycle.viewModelScope
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.repo.SeriesRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
 
-class AnimeViewModel @Inject constructor(
-    private val repo: SeriesRepository,
-    @IOContext private val ioContext: CoroutineContext
-) : ViewModel() {
-
-    private val job = Job()
-    private val ioScope = CoroutineScope(job + ioContext)
+class AnimeViewModel @Inject constructor(private val repo: SeriesRepository) : ViewModel() {
     val animeSeries: LiveData<List<SeriesModel>>
         get() = repo.anime
 
     fun updateSeries(userSeriesId: Int, newProgress: Int, newUserSeriesStatus: UserSeriesStatus) =
-        ioScope.launch {
+        viewModelScope.launch {
             repo.updateSeries(userSeriesId, newProgress, newUserSeriesStatus)
         }
-
-    override fun onCleared() {
-        super.onCleared()
-        job.cancel()
-    }
 }

--- a/app/src/main/java/com/chesire/malime/flow/series/search/SearchViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/search/SearchViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.AsyncState
-import com.chesire.malime.MainContext
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.api.SearchApi
 import com.chesire.malime.core.flags.SeriesType
@@ -17,13 +16,11 @@ import com.chesire.malime.extensions.postSuccess
 import com.chesire.malime.repo.SeriesRepository
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
 
 class SearchViewModel @Inject constructor(
     private val repo: SeriesRepository,
     private val search: SearchApi
 ) : ViewModel() {
-
     private val _searchResults = MutableLiveData<AsyncState<List<SeriesModel>, SearchError>>()
 
     val searchTitle = MutableLiveData<String>()

--- a/app/src/main/java/com/chesire/malime/flow/series/search/SearchViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/search/SearchViewModel.kt
@@ -3,8 +3,9 @@ package com.chesire.malime.flow.series.search
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.chesire.malime.AsyncState
-import com.chesire.malime.IOContext
+import com.chesire.malime.MainContext
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.api.SearchApi
 import com.chesire.malime.core.flags.SeriesType
@@ -14,20 +15,15 @@ import com.chesire.malime.extensions.postError
 import com.chesire.malime.extensions.postLoading
 import com.chesire.malime.extensions.postSuccess
 import com.chesire.malime.repo.SeriesRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 class SearchViewModel @Inject constructor(
     private val repo: SeriesRepository,
-    private val search: SearchApi,
-    @IOContext private val ioContext: CoroutineContext
+    private val search: SearchApi
 ) : ViewModel() {
 
-    private val job = SupervisorJob()
-    private val ioScope = CoroutineScope(job + ioContext)
     private val _searchResults = MutableLiveData<AsyncState<List<SeriesModel>, SearchError>>()
 
     val searchTitle = MutableLiveData<String>()
@@ -38,7 +34,7 @@ class SearchViewModel @Inject constructor(
 
     var seriesType: SeriesType = SeriesType.Anime
 
-    fun performSearch() = ioScope.launch {
+    fun performSearch() = viewModelScope.launch {
         if (searchTitle.value.isNullOrEmpty()) {
             _searchResults.postError(SearchError.MissingTitle)
             return@launch
@@ -59,7 +55,7 @@ class SearchViewModel @Inject constructor(
     }
 
     fun addSeries(model: SeriesModel, startingStatus: UserSeriesStatus) =
-        ioScope.launch {
+        viewModelScope.launch {
             val response = when (model.type) {
                 SeriesType.Anime -> repo.addAnime(model.id, startingStatus)
                 SeriesType.Manga -> repo.addManga(model.id, startingStatus)
@@ -74,9 +70,4 @@ class SearchViewModel @Inject constructor(
                 }
             }
         }
-
-    override fun onCleared() {
-        super.onCleared()
-        job.cancel()
-    }
 }

--- a/app/src/test/java/com/chesire/malime/CoroutinesMainDispatcherRule.kt
+++ b/app/src/test/java/com/chesire/malime/CoroutinesMainDispatcherRule.kt
@@ -2,7 +2,6 @@ package com.chesire.malime
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
@@ -15,12 +14,15 @@ class CoroutinesMainDispatcherRule : TestWatcher() {
 
     override fun starting(description: Description?) {
         super.starting(description)
-        Dispatchers.setMain(singleThreadExecutor.asCoroutineDispatcher())
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        // Medium article says not to set this to Unconfined, but without this it looks like it
+        // won't be on the correct thread, so will leave like this for now
+        // Dispatchers.setMain(singleThreadExecutor.asCoroutineDispatcher())
     }
 
     override fun finished(description: Description?) {
         super.finished(description)
-        singleThreadExecutor.shutdownNow()
+        // singleThreadExecutor.shutdownNow()
         Dispatchers.resetMain()
     }
 }

--- a/app/src/test/java/com/chesire/malime/CoroutinesMainDispatcherRule.kt
+++ b/app/src/test/java/com/chesire/malime/CoroutinesMainDispatcherRule.kt
@@ -1,0 +1,26 @@
+package com.chesire.malime
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.util.concurrent.Executors
+
+@ExperimentalCoroutinesApi
+class CoroutinesMainDispatcherRule : TestWatcher() {
+    private val singleThreadExecutor = Executors.newSingleThreadExecutor()
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(singleThreadExecutor.asCoroutineDispatcher())
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        singleThreadExecutor.shutdownNow()
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/chesire/malime/flow/login/details/DetailsViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/login/details/DetailsViewModelTests.kt
@@ -2,6 +2,7 @@ package com.chesire.malime.flow.login.details
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
+import com.chesire.malime.CoroutinesMainDispatcherRule
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.api.AuthApi
 import com.chesire.malime.core.models.UserModel
@@ -13,27 +14,24 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
 class DetailsViewModelTests {
     @get:Rule
-    val rule = InstantTaskExecutorRule()
-    private val testDispatcher = Dispatchers.Unconfined
+    val taskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutineRule = CoroutinesMainDispatcherRule()
 
     @Test
-    fun `empty username produces LoginStatus#EmptyUsername`() = runBlocking {
+    fun `empty username produces LoginStatus#EmptyUsername`() {
         val mockAuth = mockk<AuthApi>()
         val mockRepo = mockk<UserRepository>()
         val mockObserver = mockk<Observer<LoginStatus>> {
             every { onChanged(any()) } just Runs
         }
 
-        DetailsViewModel(mockAuth, mockRepo, testDispatcher).run {
+        DetailsViewModel(mockAuth, mockRepo).run {
             username.value = ""
             password.value = "password"
             loginStatus.observeForever(mockObserver)
@@ -44,14 +42,14 @@ class DetailsViewModelTests {
     }
 
     @Test
-    fun `empty password produces LoginStatus#EmptyPassword`() = runBlocking {
+    fun `empty password produces LoginStatus#EmptyPassword`() {
         val mockAuth = mockk<AuthApi>()
         val mockRepo = mockk<UserRepository>()
         val mockObserver = mockk<Observer<LoginStatus>> {
             every { onChanged(any()) } just Runs
         }
 
-        DetailsViewModel(mockAuth, mockRepo, testDispatcher).run {
+        DetailsViewModel(mockAuth, mockRepo).run {
             username.value = "username"
             password.value = ""
             loginStatus.observeForever(mockObserver)
@@ -62,7 +60,7 @@ class DetailsViewModelTests {
     }
 
     @Test
-    fun `login failure produces LoginStatus#Error`() = runBlocking {
+    fun `login failure produces LoginStatus#Error`() {
         val mockAuth = mockk<AuthApi> {
             coEvery { login(any(), any()) } coAnswers {
                 Resource.Error("", 0)
@@ -73,7 +71,7 @@ class DetailsViewModelTests {
             every { onChanged(any()) } just Runs
         }
 
-        DetailsViewModel(mockAuth, mockRepo, testDispatcher).run {
+        DetailsViewModel(mockAuth, mockRepo).run {
             username.value = "username"
             password.value = "password"
             loginStatus.observeForever(mockObserver)
@@ -84,20 +82,24 @@ class DetailsViewModelTests {
     }
 
     @Test
-    fun `login success begins to getUser`() = runBlocking {
+    fun `login success begins to getUser`() {
         val mockAuth = mockk<AuthApi> {
-            coEvery { login(any(), any()) } coAnswers {
+            coEvery {
+                login(any(), any())
+            } coAnswers {
                 Resource.Success(Any())
             }
-            coEvery { clearAuth() } coAnswers { }
+            coEvery { clearAuth() } just Runs
         }
         val mockRepo = mockk<UserRepository> {
-            coEvery { refreshUser() } coAnswers {
+            coEvery {
+                refreshUser()
+            } coAnswers {
                 Resource.Error("", 0)
             }
         }
 
-        DetailsViewModel(mockAuth, mockRepo, testDispatcher).run {
+        DetailsViewModel(mockAuth, mockRepo).run {
             username.value = "username"
             password.value = "password"
             login()
@@ -107,10 +109,12 @@ class DetailsViewModelTests {
     }
 
     @Test
-    fun `getUser success produces LoginStatus#Success`() = runBlocking {
+    fun `getUser success produces LoginStatus#Success`() {
         val expectedModel = mockk<UserModel>()
         val mockAuth = mockk<AuthApi> {
-            coEvery { login(any(), any()) } coAnswers {
+            coEvery {
+                login(any(), any())
+            } coAnswers {
                 Resource.Success(Any())
             }
         }
@@ -121,7 +125,7 @@ class DetailsViewModelTests {
             every { onChanged(any()) } just Runs
         }
 
-        DetailsViewModel(mockAuth, mockRepo, testDispatcher).run {
+        DetailsViewModel(mockAuth, mockRepo).run {
             username.value = "username"
             password.value = "password"
             loginStatus.observeForever(mockObserver)
@@ -132,9 +136,11 @@ class DetailsViewModelTests {
     }
 
     @Test
-    fun `getUser failure clears stored auth`() = runBlocking {
+    fun `getUser failure clears stored auth`() {
         val mockAuth = mockk<AuthApi> {
-            coEvery { login(any(), any()) } coAnswers {
+            coEvery {
+                login(any(), any())
+            } coAnswers {
                 Resource.Success(Any())
             }
             coEvery { clearAuth() } coAnswers { }
@@ -146,7 +152,7 @@ class DetailsViewModelTests {
             every { onChanged(any()) } just Runs
         }
 
-        DetailsViewModel(mockAuth, mockRepo, testDispatcher).run {
+        DetailsViewModel(mockAuth, mockRepo).run {
             username.value = "username"
             password.value = "password"
             loginStatus.observeForever(mockObserver)
@@ -157,9 +163,11 @@ class DetailsViewModelTests {
     }
 
     @Test
-    fun `getUser failure produces LoginStatus#Error`() = runBlocking {
+    fun `getUser failure produces LoginStatus#Error`() {
         val mockAuth = mockk<AuthApi> {
-            coEvery { login(any(), any()) } coAnswers {
+            coEvery {
+                login(any(), any())
+            } coAnswers {
                 Resource.Success(Any())
             }
             coEvery { clearAuth() } coAnswers { }
@@ -171,7 +179,7 @@ class DetailsViewModelTests {
             every { onChanged(any()) } just Runs
         }
 
-        DetailsViewModel(mockAuth, mockRepo, testDispatcher).run {
+        DetailsViewModel(mockAuth, mockRepo).run {
             username.value = "username"
             password.value = "password"
             loginStatus.observeForever(mockObserver)

--- a/app/src/test/java/com/chesire/malime/flow/login/syncing/SyncingViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/login/syncing/SyncingViewModelTests.kt
@@ -11,7 +11,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue

--- a/app/src/test/java/com/chesire/malime/flow/login/syncing/SyncingViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/login/syncing/SyncingViewModelTests.kt
@@ -3,6 +3,7 @@ package com.chesire.malime.flow.login.syncing
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.chesire.malime.AsyncState
+import com.chesire.malime.CoroutinesMainDispatcherRule
 import com.chesire.malime.core.Resource
 import com.chesire.malime.repo.SeriesRepository
 import io.mockk.Runs
@@ -20,8 +21,9 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class SyncingViewModelTests {
     @get:Rule
-    val rule = InstantTaskExecutorRule()
-    private val testDispatcher = Dispatchers.Unconfined
+    val taskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutineRule = CoroutinesMainDispatcherRule()
 
     @Test
     fun `syncLatestData refreshAnime failure posts error`() = runBlocking {
@@ -33,7 +35,7 @@ class SyncingViewModelTests {
             every { onChanged(any()) } just Runs
         }
 
-        SyncingViewModel(mockRepo, testDispatcher).run {
+        SyncingViewModel(mockRepo).run {
             syncStatus.observeForever(mockObserver)
             syncLatestData()
             assertTrue(syncStatus.value is AsyncState.Error)
@@ -50,7 +52,7 @@ class SyncingViewModelTests {
             every { onChanged(any()) } just Runs
         }
 
-        SyncingViewModel(mockRepo, testDispatcher).run {
+        SyncingViewModel(mockRepo).run {
             syncStatus.observeForever(mockObserver)
             syncLatestData()
             assertTrue(syncStatus.value is AsyncState.Error)
@@ -67,7 +69,7 @@ class SyncingViewModelTests {
             every { onChanged(any()) } just Runs
         }
 
-        SyncingViewModel(mockRepo, testDispatcher).run {
+        SyncingViewModel(mockRepo).run {
             syncStatus.observeForever(mockObserver)
             syncLatestData()
             assertTrue(syncStatus.value is AsyncState.Success)

--- a/app/src/test/java/com/chesire/malime/flow/series/list/anime/AnimeViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/series/list/anime/AnimeViewModelTests.kt
@@ -1,25 +1,23 @@
 package com.chesire.malime.flow.series.list.anime
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.chesire.malime.CoroutinesMainDispatcherRule
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.repo.SeriesRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
 class AnimeViewModelTests {
     @get:Rule
-    val rule = InstantTaskExecutorRule()
-    private val testDispatcher = Dispatchers.Unconfined
+    val taskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutineRule = CoroutinesMainDispatcherRule()
 
     @Test
-    fun `updateSeries sends request through the repository`() = runBlocking {
+    fun `updateSeries sends request through the repository`() {
         val mockRepo = mockk<SeriesRepository> {
             coEvery {
                 updateSeries(0, 0, UserSeriesStatus.Current)
@@ -28,9 +26,9 @@ class AnimeViewModelTests {
             }
         }
 
-        val classUnderTest = AnimeViewModel(mockRepo, testDispatcher)
+        val classUnderTest = AnimeViewModel(mockRepo)
         classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current)
 
-        coVerify { runBlocking { mockRepo.updateSeries(0, 0, UserSeriesStatus.Current) } }
+        coVerify { mockRepo.updateSeries(0, 0, UserSeriesStatus.Current) }
     }
 }

--- a/app/src/test/java/com/chesire/malime/flow/series/search/SearchViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/series/search/SearchViewModelTests.kt
@@ -15,8 +15,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -39,7 +37,7 @@ class SearchViewModelTests {
             searchResults.observeForever(mockObserver)
             performSearch()
 
-            verify { mockObserver.onChanged(any<AsyncState.Error<List<SeriesModel>, SearchError>>()) }
+            assertEquals(SearchError.MissingTitle, (searchResults.value as AsyncState.Error).error)
         }
     }
 
@@ -103,7 +101,7 @@ class SearchViewModelTests {
             seriesType = SeriesType.Anime
             performSearch()
 
-            verify { mockObserver.onChanged(any<AsyncState.Success<List<SeriesModel>, SearchError>>()) }
+            assertEquals(expected, (searchResults.value as AsyncState.Success).data)
         }
     }
 }


### PR DESCRIPTION
Change to use viewModelScope instead of relying on passing in the context