### PR TITLE
feat: add loading to series

### DIFF
--- a/app/src/main/java/com/chesire/malime/extensions/ViewExtensions.kt
+++ b/app/src/main/java/com/chesire/malime/extensions/ViewExtensions.kt
@@ -43,3 +43,13 @@ fun View.visibleIf(invisible: Boolean = false, callback: () -> Boolean) {
         if (invisible) View.INVISIBLE else View.GONE
     }
 }
+
+/**
+ * Animates the views alpha value from its current to [newAlpha].
+ */
+fun View.toAlpha(newAlpha: Float) {
+    animate().cancel()
+    animate()
+        .alpha(newAlpha)
+        .start()
+}

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesInteractionListener.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesInteractionListener.kt
@@ -10,7 +10,8 @@ interface SeriesInteractionListener {
     fun seriesSelected(imageView: ImageView, model: SeriesModel)
 
     /**
-     * Executed when the "Plus one" button has been pressed.
+     * Executed when the "Plus one" button has been pressed, the [callback] is then fired on
+     * completion.
      */
-    fun onPlusOne(model: SeriesModel)
+    fun onPlusOne(model: SeriesModel, callback: () -> Unit)
 }

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
@@ -15,13 +15,16 @@ import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.chesire.malime.R
 import com.chesire.malime.SharedPref
+import com.chesire.malime.core.Resource
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.databinding.FragmentSeriesListBinding
 import com.chesire.malime.flow.DialogHandler
 import com.chesire.malime.flow.ViewModelFactory
 import com.chesire.malime.flow.series.list.anime.AnimeFragment
 import com.chesire.malime.flow.series.list.manga.MangaFragment
+import com.google.android.material.snackbar.Snackbar
 import dagger.android.support.DaggerFragment
+import kotlinx.android.synthetic.main.fragment_series_list.fragmentSeriesListLayout
 import kotlinx.android.synthetic.main.fragment_series_list.fragmentSeriesListToolbar
 import timber.log.Timber
 import javax.inject.Inject
@@ -119,9 +122,20 @@ abstract class SeriesListFragment :
         toDetails(model, imageView to model.title)
     }
 
-    override fun onPlusOne(model: SeriesModel) {
+    override fun onPlusOne(model: SeriesModel, callback: () -> Unit) {
         Timber.i("Model ${model.slug} onPlusOne called")
-        viewModel.updateSeries(model.userId, model.progress.inc(), model.userSeriesStatus)
+        viewModel.updateSeries(model.userId, model.progress.inc(), model.userSeriesStatus) {
+            if (it is Resource.Error) {
+                Snackbar
+                    .make(
+                        fragmentSeriesListLayout,
+                        getString(R.string.list_try_again, model.title),
+                        Snackbar.LENGTH_LONG
+                    )
+                    .show()
+            }
+            callback()
+        }
     }
 
     /**

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListViewModel.kt
@@ -5,10 +5,14 @@ import androidx.lifecycle.viewModelScope
 import com.chesire.malime.AuthCaster
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.flags.UserSeriesStatus
+import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.repo.SeriesRepository
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+/**
+ * ViewModel to use with the [SeriesListFragment], handles sending updates for a series.
+ */
 class SeriesListViewModel @Inject constructor(
     private val repo: SeriesRepository,
     private val authCaster: AuthCaster
@@ -16,11 +20,20 @@ class SeriesListViewModel @Inject constructor(
     val animeSeries = repo.anime
     val mangaSeries = repo.manga
 
-    fun updateSeries(userSeriesId: Int, newProgress: Int, newUserSeriesStatus: UserSeriesStatus) =
-        viewModelScope.launch {
-            val response = repo.updateSeries(userSeriesId, newProgress, newUserSeriesStatus)
-            if (response is Resource.Error && response.code == Resource.Error.CouldNotRefresh) {
-                authCaster.issueRefreshingToken()
-            }
+    /**
+     * Sends an update for a series, will fire [callback] on completion.
+     */
+    fun updateSeries(
+        userSeriesId: Int,
+        newProgress: Int,
+        newUserSeriesStatus: UserSeriesStatus,
+        callback: (Resource<SeriesModel>) -> Unit
+    ) = viewModelScope.launch {
+        val response = repo.updateSeries(userSeriesId, newProgress, newUserSeriesStatus)
+        if (response is Resource.Error && response.code == Resource.Error.CouldNotRefresh) {
+            authCaster.issueRefreshingToken()
+        } else {
+            callback(response)
         }
+    }
 }

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesViewHolder.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesViewHolder.kt
@@ -5,19 +5,29 @@ import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.chesire.malime.core.models.SeriesModel
+import com.chesire.malime.extensions.hide
+import com.chesire.malime.extensions.show
+import com.chesire.malime.extensions.toAlpha
 import com.chesire.malime.extensions.visibleIf
 import kotlinx.android.extensions.LayoutContainer
+import kotlinx.android.synthetic.main.adapter_item_series.adapterItemProgressBar
 import kotlinx.android.synthetic.main.adapter_item_series.adapterItemSeriesImage
 import kotlinx.android.synthetic.main.adapter_item_series.adapterItemSeriesPlusOne
 import kotlinx.android.synthetic.main.adapter_item_series.adapterItemSeriesProgress
 import kotlinx.android.synthetic.main.adapter_item_series.adapterItemSeriesSubtype
 import kotlinx.android.synthetic.main.adapter_item_series.adapterItemSeriesTitle
 
+/**
+ * ViewHolder for Series items in the Anime or Manga list.
+ */
 class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
     private lateinit var seriesModel: SeriesModel
     override val containerView: View?
         get() = itemView
 
+    /**
+     * Binds the [model] data to the view.
+     */
     fun bind(model: SeriesModel) {
         seriesModel = model
 
@@ -31,8 +41,28 @@ class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContai
         ViewCompat.setTransitionName(adapterItemSeriesImage, model.title)
     }
 
+    /**
+     * Binds the [listener] to the view.
+     */
     fun bindListener(listener: SeriesInteractionListener) {
         itemView.setOnClickListener { listener.seriesSelected(adapterItemSeriesImage, seriesModel) }
-        adapterItemSeriesPlusOne.setOnClickListener { listener.onPlusOne(seriesModel) }
+        adapterItemSeriesPlusOne.setOnClickListener {
+            startUpdatingSeries()
+            listener.onPlusOne(seriesModel) {
+                finishUpdatingSeries()
+            }
+        }
+    }
+
+    private fun startUpdatingSeries() {
+        adapterItemProgressBar.show()
+        adapterItemSeriesPlusOne.isEnabled = false
+        adapterItemSeriesPlusOne.toAlpha(0.3f)
+    }
+
+    private fun finishUpdatingSeries() {
+        adapterItemProgressBar.hide()
+        adapterItemSeriesPlusOne.isEnabled = true
+        adapterItemSeriesPlusOne.toAlpha(1f)
     }
 }

--- a/app/src/main/res/layout/adapter_item_series.xml
+++ b/app/src/main/res/layout/adapter_item_series.xml
@@ -4,12 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="113dp"
-    android:elevation="4dp"
-    app:cardElevation="4dp"
     android:layout_marginLeft="@dimen/mtrl_card_spacing"
     android:layout_marginRight="@dimen/mtrl_card_spacing"
     android:layout_marginTop="@dimen/mtrl_card_spacing"
-    android:minHeight="113dp">
+    android:elevation="4dp"
+    android:minHeight="113dp"
+    app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -88,6 +88,19 @@
             android:textColor="@color/colorPrimary"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
+
+        <ProgressBar
+            android:id="@+id/adapterItemProgressBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/progress_bar_height"
+            android:indeterminate="true"
+            android:indeterminateTint="@color/colorPrimary"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/adapterItemSeriesImage"
+            tools:visibility="visible" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="filter_by_planned">Planned</string>
 
     <string name="list_plus_one">+1</string>
+    <string name="list_try_again">Series %s failed to update, please try again…</string>
 
     <string name="login_enter_details">Login using Kitsu</string>
     <string name="login_username">Username</string>

--- a/app/src/test/java/com/chesire/malime/flow/series/list/SeriesListViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/series/list/SeriesListViewModelTests.kt
@@ -5,6 +5,7 @@ import com.chesire.malime.AuthCaster
 import com.chesire.malime.CoroutinesMainDispatcherRule
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.flags.UserSeriesStatus
+import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.repo.SeriesRepository
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -13,6 +14,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -36,7 +38,7 @@ class SeriesListViewModelTests {
         val mockAuthCaster = mockk<AuthCaster>()
 
         val classUnderTest = SeriesListViewModel(mockRepo, mockAuthCaster)
-        classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current)
+        classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current, { })
 
         coVerify { mockRepo.updateSeries(0, 0, UserSeriesStatus.Current) }
     }
@@ -57,8 +59,48 @@ class SeriesListViewModelTests {
         }
 
         val classUnderTest = SeriesListViewModel(mockRepo, mockAuthCaster)
-        classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current)
+        classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current, { })
 
         verify { mockAuthCaster.issueRefreshingToken() }
+    }
+
+    @Test
+    fun `updateSeries failure not 401 invokes callback`() {
+        var condition = false
+        val mockRepo = mockk<SeriesRepository> {
+            coEvery {
+                updateSeries(0, 0, UserSeriesStatus.Current)
+            } coAnswers {
+                Resource.Error("error", Resource.Error.GenericError)
+            }
+            every { anime } returns mockk()
+            every { manga } returns mockk()
+        }
+        val mockAuthCaster = mockk<AuthCaster>()
+
+        val classUnderTest = SeriesListViewModel(mockRepo, mockAuthCaster)
+        classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current) { condition = true }
+
+        assertTrue(condition)
+    }
+
+    @Test
+    fun `updateSeries success invokes callback`() {
+        var condition = false
+        val mockRepo = mockk<SeriesRepository> {
+            coEvery {
+                updateSeries(0, 0, UserSeriesStatus.Current)
+            } coAnswers {
+                Resource.Success(mockk())
+            }
+            every { anime } returns mockk()
+            every { manga } returns mockk()
+        }
+        val mockAuthCaster = mockk<AuthCaster>()
+
+        val classUnderTest = SeriesListViewModel(mockRepo, mockAuthCaster)
+        classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current) { condition = true }
+
+        assertTrue(condition)
     }
 }

--- a/app/src/test/java/com/chesire/malime/flow/series/list/SeriesListViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/series/list/SeriesListViewModelTests.kt
@@ -5,7 +5,6 @@ import com.chesire.malime.AuthCaster
 import com.chesire.malime.CoroutinesMainDispatcherRule
 import com.chesire.malime.core.Resource
 import com.chesire.malime.core.flags.UserSeriesStatus
-import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.repo.SeriesRepository
 import io.mockk.Runs
 import io.mockk.coEvery


### PR DESCRIPTION
When increasing the series progress by 1, dim the +1 button and make it unclickable, at the same
time show a progress bar to indicate its currently active. Also added a snackbar for when a
failure occurs.