### PR TITLE
chore(deps): ensure all navigation dependencies match

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,6 @@ android {
 
 dependencies {
     ext {
-        navigation_version = "2.1.0-alpha05"
         material_dialog_version = "3.1.0"
         preferences_version = "1.1.0-rc01"
     }
@@ -89,8 +88,8 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.1.0-beta01'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0-alpha01'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0-alpha02'
-    implementation "androidx.navigation:navigation-fragment-ktx:$navigation_version"
-    implementation "androidx.navigation:navigation-ui-ktx:$navigation_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.preference:preference:$preferences_version"
     implementation "androidx.preference:preference-ktx:$preferences_version"
     implementation "androidx.room:room-runtime:$room_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,9 @@ android {
                 'WrongAnnotationOrder',
                 'XmlSpacing'
     }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
     ext.jacoco_version = '0.8.4'
     ext.kotlin_version = '1.3.41'
+    ext.nav_version = '2.1.0-beta02'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.1.0-alpha05'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"


### PR DESCRIPTION
Change to use top level ext so that the safeargs plugin uses the same dependency version