### PR TITLE
Revert "chore(deps): bump lifecycle-extensions from 2.2.0-alpha02 to 2.2.0-alpha03"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta2'
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation 'androidx.fragment:fragment-ktx:1.1.0-rc03'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0-alpha03'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0-alpha02'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0-alpha02'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"


### PR DESCRIPTION
Reverts Chesire/Malime#249

The changes mentioned below should be done alongside

Version 2.2.0-alpha03
August 7, 2019

androidx.lifecycle:lifecycle-*:2.2.0-alpha03 is released. The commits included in this version can be found here.

New features

Implementations of ViewModelStoreOwner can now optionally implement HasDefaultViewModelProviderFactory to provide a default ViewModelProvider.Factory. This has been done for Activity 1.1.0-alpha02, Fragment 1.2.0-alpha02, and Navigation 2.2.0-alpha01. (aosp/1092370, b/135716331)
API changes

ViewModelProviders.of() has been deprecated. You can pass a Fragment or FragmentActivity to the new ViewModelProvider(ViewModelStoreOwner) constructor to achieve the same functionality. (aosp/1009889)