### PR TITLE
test: fix random failing test

### DIFF
--- a/app/src/androidTest/java/com/chesire/malime/injection/components/TestComponent.kt
+++ b/app/src/androidTest/java/com/chesire/malime/injection/components/TestComponent.kt
@@ -16,6 +16,7 @@ import com.chesire.malime.injection.androidmodules.ActivityModule
 import com.chesire.malime.injection.androidmodules.FragmentModule
 import com.chesire.malime.injection.androidmodules.ViewModelModule
 import com.chesire.malime.injection.modules.AppModule
+import com.chesire.malime.injection.modules.CoroutineModule
 import com.chesire.malime.injection.modules.FakeKitsuModule
 import com.chesire.malime.injection.modules.MemoryDatabaseModule
 import com.chesire.malime.injection.modules.ServerModule
@@ -31,9 +32,10 @@ import javax.inject.Singleton
         ActivityModule::class,
         AndroidSupportInjectionModule::class,
         AppModule::class,
-        MemoryDatabaseModule::class,
+        CoroutineModule::class,
         FakeKitsuModule::class,
         FragmentModule::class,
+        MemoryDatabaseModule::class,
         ServerModule::class,
         ViewModelModule::class
     ]

--- a/app/src/main/java/com/chesire/malime/flow/ActivityViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/ActivityViewModel.kt
@@ -3,16 +3,17 @@ package com.chesire.malime.flow
 import androidx.annotation.IdRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chesire.malime.IOContext
 import com.chesire.malime.LogoutHandler
 import com.chesire.malime.R
 import com.chesire.malime.SharedPref
 import com.chesire.malime.kitsu.AuthProvider
 import com.chesire.malime.repo.UserRepository
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [ViewModel] scoped to the [Activity].
@@ -21,6 +22,7 @@ class ActivityViewModel @Inject constructor(
     private val authProvider: AuthProvider,
     private val sharedPref: SharedPref,
     private val logoutHandler: LogoutHandler,
+    @IOContext private val ioContext: CoroutineContext,
     userRepository: UserRepository
 ) : ViewModel() {
     /**
@@ -50,7 +52,7 @@ class ActivityViewModel @Inject constructor(
      * executed after the [LogoutHandler] has finished clearing its data.
      */
     fun logout(callback: () -> Unit) = viewModelScope.launch {
-        withContext(Dispatchers.IO) {
+        withContext(ioContext) {
             logoutHandler.executeLogout()
         }
 

--- a/app/src/main/java/com/chesire/malime/injection/components/AppComponent.kt
+++ b/app/src/main/java/com/chesire/malime/injection/components/AppComponent.kt
@@ -6,6 +6,7 @@ import com.chesire.malime.injection.androidmodules.ActivityModule
 import com.chesire.malime.injection.androidmodules.FragmentModule
 import com.chesire.malime.injection.androidmodules.ViewModelModule
 import com.chesire.malime.injection.modules.AppModule
+import com.chesire.malime.injection.modules.CoroutineModule
 import com.chesire.malime.injection.modules.DatabaseModule
 import com.chesire.malime.injection.modules.KitsuModule
 import com.chesire.malime.injection.modules.ServerModule
@@ -24,6 +25,7 @@ import javax.inject.Singleton
         ActivityModule::class,
         AndroidSupportInjectionModule::class,
         AppModule::class,
+        CoroutineModule::class,
         DatabaseModule::class,
         FragmentModule::class,
         KitsuModule::class,

--- a/app/src/main/java/com/chesire/malime/injection/modules/CoroutineModule.kt
+++ b/app/src/main/java/com/chesire/malime/injection/modules/CoroutineModule.kt
@@ -1,0 +1,16 @@
+package com.chesire.malime.injection.modules
+
+import com.chesire.malime.IOContext
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
+
+@Suppress("unused")
+@Module
+object CoroutineModule {
+    @Provides
+    @IOContext
+    @JvmStatic
+    fun providesIOContext(): CoroutineContext = Dispatchers.IO
+}

--- a/app/src/test/java/com/chesire/malime/CoroutinesMainDispatcherRule.kt
+++ b/app/src/test/java/com/chesire/malime/CoroutinesMainDispatcherRule.kt
@@ -10,7 +10,11 @@ import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class CoroutinesMainDispatcherRule : TestWatcher() {
-    private val testDispatcher = TestCoroutineDispatcher()
+    /**
+     * The dispatcher used during tests, accessible in order to inject the same dispatcher that the
+     * rest of the test might use.
+     */
+    val testDispatcher = TestCoroutineDispatcher()
 
     override fun starting(description: Description?) {
         super.starting(description)

--- a/app/src/test/java/com/chesire/malime/flow/ActivityViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/ActivityViewModelTests.kt
@@ -40,6 +40,7 @@ class ActivityViewModelTests {
             mockAuthProvider,
             mockSharedPref,
             mockLogoutHandler,
+            coroutineRule.testDispatcher,
             mockUserRepository
         )
 
@@ -63,6 +64,7 @@ class ActivityViewModelTests {
             mockAuthProvider,
             mockSharedPref,
             mockLogoutHandler,
+            coroutineRule.testDispatcher,
             mockUserRepository
         )
 
@@ -86,6 +88,7 @@ class ActivityViewModelTests {
             mockAuthProvider,
             mockSharedPref,
             mockLogoutHandler,
+            coroutineRule.testDispatcher,
             mockUserRepository
         )
 
@@ -96,7 +99,9 @@ class ActivityViewModelTests {
     fun `logout tells the logoutHandler to execute`() {
         val mockAuthProvider = mockk<AuthProvider>()
         val mockSharedPref = mockk<SharedPref>()
-        val mockLogoutHandler = mockk<LogoutHandler>()
+        val mockLogoutHandler = mockk<LogoutHandler> {
+            every { executeLogout() } just Runs
+        }
         val mockUserRepository = mockk<UserRepository> {
             every { user } returns mockk()
         }
@@ -105,6 +110,7 @@ class ActivityViewModelTests {
             mockAuthProvider,
             mockSharedPref,
             mockLogoutHandler,
+            coroutineRule.testDispatcher,
             mockUserRepository
         )
 
@@ -129,6 +135,7 @@ class ActivityViewModelTests {
             mockAuthProvider,
             mockSharedPref,
             mockLogoutHandler,
+            coroutineRule.testDispatcher,
             mockUserRepository
         )
 


### PR DESCRIPTION
The tests were not failing due to the coroutine not executing in time to hit the method that wasn't
mocked out; inject the coroutine context in so it will execute in order, and mock out the missing logoutHandler mock