### PR TITLE
fix: tidyup navigation

### DIFF
--- a/app/src/main/java/com/chesire/malime/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/malime/flow/Activity.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
 import androidx.navigation.findNavController
-import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
@@ -40,14 +39,16 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity)
-
         setSupportActionBar(findViewById(R.id.appBarToolbar))
         setupNavController()
-        loadGraph()
+        observeViewModel()
 
         authCaster.subscribeToAuthError(this)
 
-        observeViewModel()
+        if (!viewModel.userLoggedIn) {
+            findNavController(R.id.activityNavigation)
+                .navigate(OverviewNavGraphDirections.globalToDetailsFragment())
+        }
     }
 
     private fun observeViewModel() {
@@ -79,16 +80,6 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
         } else {
             super.onBackPressed()
         }
-    }
-
-    private fun loadGraph() {
-        (supportFragmentManager.findFragmentById(R.id.activityNavigation) as? NavHostFragment)
-            ?.navController
-            ?.apply {
-                graph = navInflater.inflate(R.navigation.nav_graph).also {
-                    it.startDestination = viewModel.startingFragment
-                }
-            }
     }
 
     private fun setupNavController() {

--- a/app/src/main/java/com/chesire/malime/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/malime/flow/Activity.kt
@@ -5,6 +5,8 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.TextView
 import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_LOCKED_CLOSED
+import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_UNLOCKED
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
@@ -96,6 +98,12 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
         )
 
         setupActionBarWithNavController(nav, appBarConfiguration)
+        nav.addOnDestinationChangedListener { _, destination, _ ->
+            when (destination.id) {
+                R.id.detailsFragment, R.id.syncingFragment -> disableDrawer()
+                else -> enableDrawer()
+            }
+        }
     }
 
     override fun onSupportNavigateUp() =
@@ -118,5 +126,15 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
                 )
             }
         }
+    }
+
+    private fun disableDrawer() {
+        supportActionBar?.hide()
+        activityDrawer.setDrawerLockMode(LOCK_MODE_LOCKED_CLOSED)
+    }
+
+    private fun enableDrawer() {
+        supportActionBar?.show()
+        activityDrawer.setDrawerLockMode(LOCK_MODE_UNLOCKED)
     }
 }

--- a/app/src/main/java/com/chesire/malime/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/malime/flow/Activity.kt
@@ -85,8 +85,6 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
     }
 
     private fun setupNavController() {
-        val nav = findNavController(R.id.activityNavigation)
-        findViewById<NavigationView>(R.id.activityNavigationView).setupWithNavController(nav)
         appBarConfiguration = AppBarConfiguration(
             setOf(
                 R.id.animeFragment,
@@ -97,11 +95,14 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
             findViewById(R.id.activityDrawer)
         )
 
-        setupActionBarWithNavController(nav, appBarConfiguration)
-        nav.addOnDestinationChangedListener { _, destination, _ ->
-            when (destination.id) {
-                R.id.detailsFragment, R.id.syncingFragment -> disableDrawer()
-                else -> enableDrawer()
+        with(findNavController(R.id.activityNavigation)) {
+            findViewById<NavigationView>(R.id.activityNavigationView).setupWithNavController(this)
+            setupActionBarWithNavController(this, appBarConfiguration)
+            addOnDestinationChangedListener { _, destination, _ ->
+                when (destination.id) {
+                    R.id.detailsFragment, R.id.syncingFragment -> disableDrawer()
+                    else -> enableDrawer()
+                }
             }
         }
     }

--- a/app/src/main/java/com/chesire/malime/flow/ActivityViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/ActivityViewModel.kt
@@ -1,11 +1,9 @@
 package com.chesire.malime.flow
 
-import androidx.annotation.IdRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.IOContext
 import com.chesire.malime.LogoutHandler
-import com.chesire.malime.R
 import com.chesire.malime.kitsu.AuthProvider
 import com.chesire.malime.repo.UserRepository
 import kotlinx.coroutines.launch
@@ -29,17 +27,10 @@ class ActivityViewModel @Inject constructor(
     val user = userRepository.user
 
     /**
-     * Checks against stored data to decide which fragment should be displayed on start.
+     * Checks if the user is currently logged in.
      */
-    val startingFragment: Int
-        @IdRes
-        get() {
-            return if (authProvider.accessToken.isEmpty()) {
-                R.id.detailsFragment
-            } else {
-                R.id.animeFragment
-            }
-        }
+    val userLoggedIn: Boolean
+        get() = authProvider.accessToken.isNotEmpty()
 
     /**
      * Logs the user out and returns the user back to entering the login details. [callback] is

--- a/app/src/main/res/layout/view_content.xml
+++ b/app/src/main/res/layout/view_content.xml
@@ -13,6 +13,7 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:defaultNavHost="true" />
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/overview_nav_graph"
-    tools:ignore="InvalidNavigation,UnusedNavigation">
+    app:startDestination="@id/animeFragment">
 
     <!-- OOB -->
     <fragment

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -84,7 +84,7 @@
     <action
         android:id="@+id/globalToDetailsFragment"
         app:destination="@id/detailsFragment"
-        app:popUpTo="@id/detailsFragment"
+        app:popUpTo="@+id/overview_nav_graph"
         app:popUpToInclusive="true" />
     <!-- End Global Actions -->
 </navigation>

--- a/app/src/test/java/com/chesire/malime/flow/ActivityViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/ActivityViewModelTests.kt
@@ -3,7 +3,6 @@ package com.chesire.malime.flow
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.chesire.malime.CoroutinesMainDispatcherRule
 import com.chesire.malime.LogoutHandler
-import com.chesire.malime.R
 import com.chesire.malime.kitsu.AuthProvider
 import com.chesire.malime.repo.UserRepository
 import io.mockk.Runs
@@ -12,7 +11,8 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -21,9 +21,10 @@ class ActivityViewModelTests {
     val taskExecutorRule = InstantTaskExecutorRule()
     @get:Rule
     val coroutineRule = CoroutinesMainDispatcherRule()
+    private val testDispatcher = coroutineRule.testDispatcher
 
     @Test
-    fun `startingFragment with no accessToken, starts at login`() {
+    fun `userLoggedIn failure returns false`() {
         val mockAuthProvider = mockk<AuthProvider> {
             every { accessToken } returns ""
         }
@@ -35,15 +36,15 @@ class ActivityViewModelTests {
         val classUnderTest = ActivityViewModel(
             mockAuthProvider,
             mockLogoutHandler,
-            coroutineRule.testDispatcher,
+            testDispatcher,
             mockUserRepository
         )
 
-        assertEquals(R.id.detailsFragment, classUnderTest.startingFragment)
+        assertFalse(classUnderTest.userLoggedIn)
     }
 
     @Test
-    fun `startingFragment with accessToken, starts at anime`() {
+    fun `userLoggedIn success returns true`() {
         val mockAuthProvider = mockk<AuthProvider> {
             every { accessToken } returns "access token"
         }
@@ -55,11 +56,11 @@ class ActivityViewModelTests {
         val classUnderTest = ActivityViewModel(
             mockAuthProvider,
             mockLogoutHandler,
-            coroutineRule.testDispatcher,
+            testDispatcher,
             mockUserRepository
         )
 
-        assertEquals(R.id.animeFragment, classUnderTest.startingFragment)
+        assertTrue(classUnderTest.userLoggedIn)
     }
 
     @Test
@@ -75,7 +76,7 @@ class ActivityViewModelTests {
         val classUnderTest = ActivityViewModel(
             mockAuthProvider,
             mockLogoutHandler,
-            coroutineRule.testDispatcher,
+            testDispatcher,
             mockUserRepository
         )
 
@@ -98,7 +99,7 @@ class ActivityViewModelTests {
         val classUnderTest = ActivityViewModel(
             mockAuthProvider,
             mockLogoutHandler,
-            coroutineRule.testDispatcher,
+            testDispatcher,
             mockUserRepository
         )
 


### PR DESCRIPTION
Tidy up some parts of navigation, like showing the title correctly on activity recreation, and hiding the navigation bar bar where required.