### PR TITLE
fix: stop possibility of creating multiple bottom sheets

### DIFF
--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
@@ -45,6 +45,7 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
     }
 
     private lateinit var seriesAdapter: SeriesAdapter
+    private var seriesDetail: SeriesDetailSheetFragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -90,10 +91,17 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
 
     override fun seriesSelected(imageView: ImageView, model: SeriesModel) {
         Timber.i("seriesSelected called with Model ${model.slug}")
-        SeriesDetailSheetFragment.newInstance(model).show(
-            childFragmentManager,
-            SeriesDetailSheetFragment.TAG
-        )
+
+        if (seriesDetail?.isVisible == true) {
+            Timber.w("Attempt to open series detail while already visible")
+        } else {
+            seriesDetail = SeriesDetailSheetFragment.newInstance(model).also {
+                it.show(
+                    childFragmentManager,
+                    SeriesDetailSheetFragment.TAG
+                )
+            }
+        }
     }
 
     override fun onPlusOne(model: SeriesModel, callback: () -> Unit) {


### PR DESCRIPTION
Store the detail fragment in the list, and when pressing a list item to display the series detail,
check if it is already visible before opening