### PR TITLE
fix: stop focus from going to the edittext

### DIFF
--- a/app/src/main/res/layout/fragment_series_detail.xml
+++ b/app/src/main/res/layout/fragment_series_detail.xml
@@ -3,7 +3,9 @@
     android:id="@+id/seriesDetailLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:elevation="@dimen/bottom_sheet_elevation">
+    android:elevation="@dimen/bottom_sheet_elevation"
+    android:focusable="true"
+    android:focusableInTouchMode="true">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
When loading the bottom sheet, the edittext should not have a focus, allowing the user to choose
what to change