### PR TITLE
refactor: move logout to activity

### DIFF
--- a/app/src/androidTest/java/com/chesire/malime/flow/ActivityTests.kt
+++ b/app/src/androidTest/java/com/chesire/malime/flow/ActivityTests.kt
@@ -6,6 +6,7 @@ import com.chesire.malime.R
 import com.chesire.malime.helpers.injector
 import com.chesire.malime.kitsu.AuthProvider
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist
 import com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn
 import com.schibsted.spain.barista.interaction.BaristaDrawerInteractions.openDrawer
 import com.schibsted.spain.barista.rule.cleardata.ClearPreferencesRule
@@ -79,5 +80,27 @@ class ActivityTests {
         openDrawer()
         clickOn(R.string.nav_settings)
         assertDisplayed(R.string.settings_version)
+    }
+
+    @Test
+    fun acceptingLogoutExits() {
+        activity.launchActivity(null)
+        openDrawer()
+
+        clickOn(R.string.menu_logout)
+        clickOn(R.string.menu_logout_prompt_confirm)
+
+        assertDisplayed(R.id.detailsLayout)
+    }
+
+    @Test
+    fun decliningLogoutRemains() {
+        activity.launchActivity(null)
+        openDrawer()
+
+        clickOn(R.string.menu_logout)
+        clickOn(R.string.menu_logout_prompt_cancel)
+
+        assertNotExist(R.id.detailsLayout)
     }
 }

--- a/app/src/androidTest/java/com/chesire/malime/flow/settings/SettingsTests.kt
+++ b/app/src/androidTest/java/com/chesire/malime/flow/settings/SettingsTests.kt
@@ -43,28 +43,6 @@ class SettingsTests {
     }
 
     @Test
-    fun acceptingLogoutExits() {
-        activity.launchActivity(null)
-        navigateToSettings()
-
-        clickOn(R.string.settings_logout)
-        clickOn(R.string.settings_logout_prompt_confirm)
-
-        verifyNotOnSettings()
-    }
-
-    @Test
-    fun decliningLogoutRemains() {
-        activity.launchActivity(null)
-        navigateToSettings()
-
-        clickOn(R.string.settings_logout)
-        clickOn(R.string.settings_logout_prompt_cancel)
-
-        verifyOnSettings()
-    }
-
-    @Test
     @Ignore("Can't make this work without UIAutomator it looks like")
     fun privacyPolicyOpensNewPage() {
         activity.launchActivity(null)

--- a/app/src/main/java/com/chesire/malime/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/malime/flow/Activity.kt
@@ -30,6 +30,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @LogLifecykle
+@Suppress("TooManyFunctions")
 class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
     @Inject
     lateinit var authCaster: AuthCaster
@@ -133,9 +134,6 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
         }
     }
 
-    /**
-     * Sends a logout request to the [viewModel] to handle.
-     */
     private fun performLogout() {
         Timber.w("Logout called, now attempting")
         viewModel.logout {

--- a/app/src/main/java/com/chesire/malime/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/malime/flow/Activity.kt
@@ -3,6 +3,7 @@ package com.chesire.malime.flow
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.MenuItem
 import android.widget.TextView
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_LOCKED_CLOSED
@@ -15,6 +16,8 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.lifecycle.lifecycleOwner
 import com.bumptech.glide.Glide
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.AuthCaster
@@ -46,7 +49,6 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
         observeViewModel()
 
         authCaster.subscribeToAuthError(this)
-
         if (!viewModel.userLoggedIn) {
             findNavController(R.id.activityNavigation)
                 .navigate(OverviewNavGraphDirections.globalToDetailsFragment())
@@ -112,13 +114,29 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
 
     override fun unableToRefresh() {
         Timber.w("unableToRefresh has occurred")
-        logout()
+        performLogout()
+    }
+
+    /**
+     * Shows a dialog asking the user if they wish to logout.
+     * This is called from the menu_navigation.xml menu resource in order to allow it to still
+     * function while using the nav component.
+     */
+    fun requestUserLogout(@Suppress("UNUSED_PARAMETER") item: MenuItem) {
+        MaterialDialog(this).show {
+            message(R.string.menu_logout_prompt_message)
+            positiveButton(R.string.menu_logout_prompt_confirm) {
+                performLogout()
+            }
+            negativeButton(R.string.menu_logout_prompt_cancel)
+            lifecycleOwner(this@Activity)
+        }
     }
 
     /**
      * Sends a logout request to the [viewModel] to handle.
      */
-    fun logout() {
+    private fun performLogout() {
         Timber.w("Logout called, now attempting")
         viewModel.logout {
             Handler(Looper.getMainLooper()).post {

--- a/app/src/main/java/com/chesire/malime/flow/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chesire/malime/flow/settings/SettingsFragment.kt
@@ -1,46 +1,28 @@
 package com.chesire.malime.flow.settings
 
-import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.lifecycle.lifecycleOwner
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.R
-import com.chesire.malime.flow.Activity
 import timber.log.Timber
 
 @LogLifecykle
 class SettingsFragment : PreferenceFragmentCompat() {
-    private lateinit var keyLogOut: String
     private lateinit var keyPrivacyPolicy: String
     private lateinit var keyLicenses: String
 
-    // Use the activity to force log out
-    private lateinit var parentActivity: Activity
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        parentActivity = checkNotNull(activity as? Activity) {
-            "Activity hosting SettingsFragment was not Activity class"
-        }
-    }
-
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
-        keyLogOut = getString(R.string.key_log_out)
         keyPrivacyPolicy = getString(R.string.key_privacy_policy)
         keyLicenses = getString(R.string.key_licenses)
     }
 
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {
         when (preference?.key) {
-            keyLogOut -> showLogoutDialog()
             keyPrivacyPolicy -> showPrivacyPolicy()
             keyLicenses -> showLicenses()
             else -> {
@@ -50,17 +32,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         return true
-    }
-
-    private fun showLogoutDialog() {
-        MaterialDialog(requireContext()).show {
-            message(R.string.settings_logout_prompt_message)
-            positiveButton(R.string.settings_logout_prompt_confirm) {
-                parentActivity.logout()
-            }
-            negativeButton(R.string.settings_logout_prompt_cancel)
-            lifecycleOwner(viewLifecycleOwner)
-        }
     }
 
     private fun showPrivacyPolicy() {

--- a/app/src/main/res/drawable/ic_exit_to_app.xml
+++ b/app/src/main/res/drawable/ic_exit_to_app.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10.09,15.59L11.5,17l5,-5 -5,-5 -1.41,1.41L12.67,11H3v2h9.67l-2.58,2.59zM19,3H5c-1.11,0 -2,0.9 -2,2v4h2V5h14v14H5v-4H3v4c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/menu/menu_navigation.xml
+++ b/app/src/main/res/menu/menu_navigation.xml
@@ -37,6 +37,7 @@
         <item
             android:id="@+id/logoutNavigation"
             android:icon="@drawable/ic_exit_to_app"
-            android:title="@string/menu_logout" />
+            android:title="@string/menu_logout"
+            android:onClick="requestUserLogout"/>
     </group>
 </menu>

--- a/app/src/main/res/menu/menu_navigation.xml
+++ b/app/src/main/res/menu/menu_navigation.xml
@@ -4,7 +4,9 @@
     tools:ignore="MatchingMenuId"
     tools:showIn="activityNavigationView">
 
-    <group android:checkableBehavior="single">
+    <group
+        android:id="@+id/navigationMenuPrimary"
+        android:checkableBehavior="single">
 
         <item
             android:id="@+id/animeFragment"
@@ -24,11 +26,17 @@
             android:title="@string/nav_profile" />
     </group>
 
-    <group android:checkableBehavior="none">
+    <group
+        android:id="@+id/navigationMenuSecondary"
+        android:checkableBehavior="none">
 
         <item
             android:id="@+id/settingsFragment"
             android:icon="@drawable/ic_settings_white"
             android:title="@string/nav_settings" />
+        <item
+            android:id="@+id/logoutNavigation"
+            android:icon="@drawable/ic_exit_to_app"
+            android:title="@string/settings_logout" />
     </group>
 </menu>

--- a/app/src/main/res/menu/menu_navigation.xml
+++ b/app/src/main/res/menu/menu_navigation.xml
@@ -37,6 +37,6 @@
         <item
             android:id="@+id/logoutNavigation"
             android:icon="@drawable/ic_exit_to_app"
-            android:title="@string/settings_logout" />
+            android:title="@string/menu_logout" />
     </group>
 </menu>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="key_log_out" translatable="false">keyLogOut</string>
     <string name="key_privacy_policy" translatable="false">keyPrivacyPolicy</string>
     <string name="key_licenses" translatable="false">keyLicenses</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <PreferenceCategory android:title="@string/settings_general_category">
-        <Preference
-            android:key="@string/key_log_out"
-            android:summary="@string/settings_logout_summary"
-            android:title="@string/settings_logout" />
-    </PreferenceCategory>
-
     <PreferenceCategory android:title="@string/settings_about_category">
         <Preference
             android:summary="@string/version"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -13,6 +13,11 @@
     <string name="menu_filter">Filter</string>
     <string name="menu_sort">Sort</string>
     <string name="menu_settings">Settings</string>
+    <string name="menu_logout">Log out</string>
+    <string name="menu_logout_summary">Log out of Kitsu account</string>
+    <string name="menu_logout_prompt_message">Are you sure you wish to log out of your Kitsu account?</string>
+    <string name="menu_logout_prompt_confirm">Confirm</string>
+    <string name="menu_logout_prompt_cancel">Cancel</string>
 
     <string name="sort_dialog_title">Sort by</string>
     <string name="sort_by_default">Default</string>
@@ -58,11 +63,6 @@
     <string name="settings_version">Version</string>
     <string name="settings_licenses">Licenses</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
-    <string name="settings_logout">Log out</string>
-    <string name="settings_logout_summary">Log out of Kitsu account</string>
-    <string name="settings_logout_prompt_message">Are you sure you wish to log out of your Kitsu account?</string>
-    <string name="settings_logout_prompt_confirm">Confirm</string>
-    <string name="settings_logout_prompt_cancel">Cancel</string>
 
     <string name="series_detail_dash">-</string>
     <string name="series_detail_progress_title">Progress</string>


### PR DESCRIPTION
Move the logout button so instead of it being in the settings, it now exists within the navigation drawer for easier access.