### PR TITLE
feat: get deletion confirmation

### DIFF
--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesAdapter.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesAdapter.kt
@@ -23,7 +23,19 @@ class SeriesAdapter(
         sharedPref.subscribeToChanges(this)
     }
 
-    private var completeList: MutableList<SeriesModel> = mutableListOf()
+    private var completeList = mutableListOf<SeriesModel>()
+
+    /**
+     * Execute when an item has been swiped away in the adapter.
+     */
+    fun attemptDeleteItem(position: Int, callback: (Boolean) -> Unit) {
+        listener.seriesDelete(getItem(position), position) { confirmed ->
+            if (!confirmed) {
+                notifyDataSetChanged()
+            }
+            callback(confirmed)
+        }
+    }
 
     override fun submitList(list: MutableList<SeriesModel>?) {
         if (list == null) {

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesAdapter.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesAdapter.kt
@@ -31,10 +31,11 @@ class SeriesAdapter(
      * Execute when an item has been swiped away in the adapter.
      */
     fun attemptDeleteItem(position: Int) {
-        listener.seriesDelete(getItem(position), position) { confirmed ->
+        val model = getItem(position)
+        listener.seriesDelete(model) { confirmed ->
             container?.findViewHolderForAdapterPosition(position)?.let { viewHolder ->
                 if (confirmed) {
-                    // nothing for now
+                    submitList(completeList.minus(model).toMutableList())
                 } else {
                     notifyDataSetChanged()
                     viewHolder.itemView.alpha = 1f

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesAdapter.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesAdapter.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.chesire.malime.R
 import com.chesire.malime.core.SharedPref
 import com.chesire.malime.core.flags.SortOption
@@ -23,17 +24,22 @@ class SeriesAdapter(
         sharedPref.subscribeToChanges(this)
     }
 
+    private var container: RecyclerView? = null
     private var completeList = mutableListOf<SeriesModel>()
 
     /**
      * Execute when an item has been swiped away in the adapter.
      */
-    fun attemptDeleteItem(position: Int, callback: (Boolean) -> Unit) {
+    fun attemptDeleteItem(position: Int) {
         listener.seriesDelete(getItem(position), position) { confirmed ->
-            if (!confirmed) {
-                notifyDataSetChanged()
-            }
-            callback(confirmed)
+            container?.findViewHolderForAdapterPosition(position)?.let { viewHolder ->
+                if (confirmed) {
+                    // nothing for now
+                } else {
+                    notifyDataSetChanged()
+                    viewHolder.itemView.alpha = 1f
+                }
+            } ?: notifyDataSetChanged() // just call notifyDataSetChanged to reset some state
         }
     }
 
@@ -45,6 +51,11 @@ class SeriesAdapter(
             completeList = list
             super.submitList(executeSort(executeFilter(list)))
         }
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        container = recyclerView
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SeriesViewHolder {

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesInteractionListener.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesInteractionListener.kt
@@ -19,5 +19,5 @@ interface SeriesInteractionListener {
      * Executed when a series has been chosen for deletion, The [callback] is fired on completion
      * with a value of true if deletion is confirmed, or false if it is cancelled.
      */
-    fun seriesDelete(model: SeriesModel, position: Int, callback: (Boolean) -> Unit)
+    fun seriesDelete(model: SeriesModel, callback: (Boolean) -> Unit)
 }

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesInteractionListener.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesInteractionListener.kt
@@ -14,4 +14,10 @@ interface SeriesInteractionListener {
      * completion.
      */
     fun onPlusOne(model: SeriesModel, callback: () -> Unit)
+
+    /**
+     * Executed when a series has been chosen for deletion, The [callback] is fired on completion
+     * with a value of true if deletion is confirmed, or false if it is cancelled.
+     */
+    fun seriesDelete(model: SeriesModel, position: Int, callback: (Boolean) -> Unit)
 }

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListDeleteError.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListDeleteError.kt
@@ -1,0 +1,9 @@
+package com.chesire.malime.flow.series.list
+
+/**
+ * List of errors that can occur for failure to delete a series.
+ */
+enum class SeriesListDeleteError {
+    None,
+    DeletionFailure
+}

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
@@ -39,6 +39,7 @@ import javax.inject.Inject
  * Provides a base fragment for the [AnimeFragment] & [MangaFragment] to inherit from, performing
  * most of the setup and interaction.
  */
+@Suppress("TooManyFunctions")
 abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
@@ -12,6 +12,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.callbacks.onCancel
+import com.afollestad.materialdialogs.lifecycle.lifecycleOwner
 import com.chesire.malime.R
 import com.chesire.malime.core.SharedPref
 import com.chesire.malime.core.models.SeriesModel
@@ -68,7 +71,7 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
             adapter = seriesAdapter
             layoutManager = LinearLayoutManager(requireContext())
             setHasFixedSize(true)
-            val itemTouchHelper = ItemTouchHelper(SwipeToDelete())
+            val itemTouchHelper = ItemTouchHelper(SwipeToDelete(seriesAdapter))
             itemTouchHelper.attachToRecyclerView(this)
         }
     }.root
@@ -121,6 +124,23 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
                     .show()
             }
             callback()
+        }
+    }
+
+    override fun seriesDelete(model: SeriesModel, position: Int, callback: (Boolean) -> Unit) {
+        MaterialDialog(requireContext()).show {
+            title(text = getString(R.string.series_list_delete_title, model.title))
+            positiveButton(R.string.series_list_delete_confirm) {
+                // TODO: send request to vm for it to update
+                callback(true)
+            }
+            negativeButton(R.string.series_list_delete_cancel) {
+                callback(false)
+            }
+            onCancel {
+                callback(false)
+            }
+            lifecycleOwner(viewLifecycleOwner)
         }
     }
 

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
@@ -127,7 +127,7 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
         }
     }
 
-    override fun seriesDelete(model: SeriesModel, position: Int, callback: (Boolean) -> Unit) {
+    override fun seriesDelete(model: SeriesModel, callback: (Boolean) -> Unit) {
         MaterialDialog(requireContext()).show {
             title(text = getString(R.string.series_list_delete_title, model.title))
             positiveButton(R.string.series_list_delete_confirm) {

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListFragment.kt
@@ -132,6 +132,7 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
             title(text = getString(R.string.series_list_delete_title, model.title))
             positiveButton(R.string.series_list_delete_confirm) {
                 // TODO: send request to vm for it to update
+                // If the request fails, notify the adapter to reset
                 callback(true)
             }
             negativeButton(R.string.series_list_delete_cancel) {

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListViewModel.kt
@@ -1,5 +1,6 @@
 package com.chesire.malime.flow.series.list
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.AuthCaster
@@ -7,6 +8,7 @@ import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.series.SeriesRepository
 import com.chesire.malime.server.Resource
+import com.hadilq.liveevent.LiveEvent
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,6 +21,9 @@ class SeriesListViewModel @Inject constructor(
 ) : ViewModel() {
     val animeSeries = repo.anime
     val mangaSeries = repo.manga
+
+    private val _deletionStatus = LiveEvent<SeriesListDeleteError>()
+    val deletionStatus: LiveData<SeriesListDeleteError> = _deletionStatus
 
     /**
      * Sends an update for a series, will fire [callback] on completion.
@@ -34,6 +39,21 @@ class SeriesListViewModel @Inject constructor(
             authCaster.issueRefreshingToken()
         } else {
             callback(response)
+        }
+    }
+
+    /**
+     * Sends a delete request to the repository, will notify status on [deletionStatus] with
+     * [SeriesListDeleteError.DeletionFailure] if a failure occurs.
+     */
+    fun deleteSeries(seriesModel: SeriesModel) = viewModelScope.launch {
+        val response = repo.deleteSeries(seriesModel)
+        if (response is Resource.Error) {
+            if (response.code == Resource.Error.CouldNotRefresh) {
+                authCaster.issueRefreshingToken()
+            } else {
+                _deletionStatus.postValue(SeriesListDeleteError.DeletionFailure)
+            }
         }
     }
 }

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListViewModel.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SeriesListViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.AuthCaster
+import com.chesire.malime.core.extensions.postError
+import com.chesire.malime.core.flags.AsyncState
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.series.SeriesRepository
@@ -22,8 +24,8 @@ class SeriesListViewModel @Inject constructor(
     val animeSeries = repo.anime
     val mangaSeries = repo.manga
 
-    private val _deletionStatus = LiveEvent<SeriesListDeleteError>()
-    val deletionStatus: LiveData<SeriesListDeleteError> = _deletionStatus
+    private val _deletionStatus = LiveEvent<AsyncState<SeriesModel, SeriesListDeleteError>>()
+    val deletionStatus: LiveData<AsyncState<SeriesModel, SeriesListDeleteError>> = _deletionStatus
 
     /**
      * Sends an update for a series, will fire [callback] on completion.
@@ -52,7 +54,7 @@ class SeriesListViewModel @Inject constructor(
             if (response.code == Resource.Error.CouldNotRefresh) {
                 authCaster.issueRefreshingToken()
             } else {
-                _deletionStatus.postValue(SeriesListDeleteError.DeletionFailure)
+                _deletionStatus.postError(seriesModel, SeriesListDeleteError.DeletionFailure)
             }
         }
     }

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SwipeToDelete.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SwipeToDelete.kt
@@ -9,10 +9,13 @@ private const val FADE_BUFFER = 90
 /**
  * [ItemTouchHelper] that fades a view out to allow deletion.
  */
-class SwipeToDelete : ItemTouchHelper.SimpleCallback(
+class SwipeToDelete(
+    private val adapter: SeriesAdapter
+) : ItemTouchHelper.SimpleCallback(
     0,
     ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
 ) {
+
     // No implementation required
     override fun onMove(
         recyclerView: RecyclerView,
@@ -21,10 +24,13 @@ class SwipeToDelete : ItemTouchHelper.SimpleCallback(
     ) = false
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-        // notify the adapter, and fragment?
-
-        // val position = viewHolder.adapterPosition
-        // mAdapter.deleteItem(position)
+        adapter.attemptDeleteItem(viewHolder.adapterPosition) { confirmed ->
+            if (confirmed) {
+                // TODO: show loading view
+            } else {
+                viewHolder.itemView.alpha = 1f
+            }
+        }
     }
 
     override fun onChildDraw(

--- a/app/src/main/java/com/chesire/malime/flow/series/list/SwipeToDelete.kt
+++ b/app/src/main/java/com/chesire/malime/flow/series/list/SwipeToDelete.kt
@@ -15,23 +15,14 @@ class SwipeToDelete(
     0,
     ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
 ) {
-
-    // No implementation required
     override fun onMove(
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
-    ) = false
+    ) = false // No implementation required
 
-    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-        adapter.attemptDeleteItem(viewHolder.adapterPosition) { confirmed ->
-            if (confirmed) {
-                // TODO: show loading view
-            } else {
-                viewHolder.itemView.alpha = 1f
-            }
-        }
-    }
+    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) =
+        adapter.attemptDeleteItem(viewHolder.adapterPosition)
 
     override fun onChildDraw(
         c: Canvas,

--- a/app/src/test/java/com/chesire/malime/flow/series/list/SeriesListViewModelTests.kt
+++ b/app/src/test/java/com/chesire/malime/flow/series/list/SeriesListViewModelTests.kt
@@ -1,9 +1,13 @@
 package com.chesire.malime.flow.series.list
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
 import com.chesire.malime.AuthCaster
 import com.chesire.malime.CoroutinesMainDispatcherRule
+import com.chesire.malime.core.flags.AsyncState
 import com.chesire.malime.core.flags.UserSeriesStatus
+import com.chesire.malime.core.models.SeriesModel
+import com.chesire.malime.createSeriesModel
 import com.chesire.malime.series.SeriesRepository
 import com.chesire.malime.server.Resource
 import io.mockk.Runs
@@ -43,7 +47,7 @@ class SeriesListViewModelTests {
     }
 
     @Test
-    fun `updateSeries 401 failure notifies through AuthCaster`() {
+    fun `updateSeries CouldNotRefresh failure notifies through AuthCaster`() {
         val mockRepo = mockk<SeriesRepository> {
             coEvery {
                 updateSeries(0, 0, UserSeriesStatus.Current)
@@ -64,7 +68,7 @@ class SeriesListViewModelTests {
     }
 
     @Test
-    fun `updateSeries failure not 401 invokes callback`() {
+    fun `updateSeries failure not CouldNotRefresh invokes callback`() {
         var condition = false
         val mockRepo = mockk<SeriesRepository> {
             coEvery {
@@ -101,5 +105,49 @@ class SeriesListViewModelTests {
         classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current) { condition = true }
 
         assertTrue(condition)
+    }
+
+    @Test
+    fun `deleteSeries CouldNotRefresh failure notifies through AuthCaster`() {
+        val mockRepo = mockk<SeriesRepository> {
+            coEvery {
+                deleteSeries(any())
+            } coAnswers {
+                Resource.Error("error", Resource.Error.CouldNotRefresh)
+            }
+            every { anime } returns mockk()
+            every { manga } returns mockk()
+        }
+        val mockAuthCaster = mockk<AuthCaster> {
+            every { issueRefreshingToken() } just Runs
+        }
+
+        val classUnderTest = SeriesListViewModel(mockRepo, mockAuthCaster)
+        classUnderTest.deleteSeries(createSeriesModel())
+
+        verify { mockAuthCaster.issueRefreshingToken() }
+    }
+
+    @Test
+    fun `deleteSeries not CouldNotRefresh failure updates live data`() {
+        val mockRepo = mockk<SeriesRepository> {
+            coEvery {
+                deleteSeries(any())
+            } coAnswers {
+                Resource.Error("error", Resource.Error.GenericError)
+            }
+            every { anime } returns mockk()
+            every { manga } returns mockk()
+        }
+        val mockAuthCaster = mockk<AuthCaster>()
+        val mockObserver = mockk<Observer<AsyncState<SeriesModel, SeriesListDeleteError>>>() {
+            every { onChanged(any()) } just Runs
+        }
+
+        val classUnderTest = SeriesListViewModel(mockRepo, mockAuthCaster)
+        classUnderTest.deletionStatus.observeForever(mockObserver)
+        classUnderTest.deleteSeries(createSeriesModel())
+
+        verify { mockObserver.onChanged(any()) }
     }
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="series_list_delete_title">Are you sure you want to delete %s?</string>
     <string name="series_list_delete_confirm">Confirm</string>
     <string name="series_list_delete_cancel">Cancel</string>
+    <string name="series_list_delete_failure">Encountered error trying to delete series</string>
 
     <string name="series_detail_dash">-</string>
     <string name="series_detail_progress_title">Progress</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -64,6 +64,10 @@
     <string name="settings_licenses">Licenses</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
 
+    <string name="series_list_delete_title">Are you sure you want to delete %s?</string>
+    <string name="series_list_delete_confirm">Confirm</string>
+    <string name="series_list_delete_cancel">Cancel</string>
+
     <string name="series_detail_dash">-</string>
     <string name="series_detail_progress_title">Progress</string>
     <string name="series_detail_progress_out_of">/ %s</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="series_list_delete_confirm">Confirm</string>
     <string name="series_list_delete_cancel">Cancel</string>
     <string name="series_list_delete_failure">Encountered error trying to delete series</string>
+    <string name="series_list_delete_retry">Retry</string>
 
     <string name="series_detail_dash">-</string>
     <string name="series_detail_progress_title">Progress</string>


### PR DESCRIPTION
Show a dialog when a series is attempted to be deleted. If the user cancels the dialog, then the series should be displayed back on the view as per normal, if they confirm the dialog the series should be deleted.