### PR TITLE
fix: jsonadapter issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
     liveevent_version = "1.0.1"
     material_version = "1.2.0-alpha01"
     materialdialog_version = "3.1.1"
-    moshi_version = "1.9.1"
+    moshi_version = "1.8.0"
     preferences_version = "1.1.0"
     room_version = "2.2.1"
     timber_version = "4.7.1"

--- a/core/src/main/java/com/chesire/malime/core/models/SeriesModel.kt
+++ b/core/src/main/java/com/chesire/malime/core/models/SeriesModel.kt
@@ -9,6 +9,7 @@ import com.chesire.malime.core.flags.SeriesStatus
 import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.flags.Subtype
 import com.chesire.malime.core.flags.UserSeriesStatus
+import com.squareup.moshi.JsonClass
 import kotlinx.android.parcel.IgnoredOnParcel
 import kotlinx.android.parcel.Parcelize
 
@@ -17,6 +18,7 @@ import kotlinx.android.parcel.Parcelize
  */
 @Parcelize
 @Entity
+@JsonClass(generateAdapter = true)
 data class SeriesModel(
     @PrimaryKey
     val id: Int,

--- a/core/src/main/java/com/chesire/malime/core/models/UserModel.kt
+++ b/core/src/main/java/com/chesire/malime/core/models/UserModel.kt
@@ -3,11 +3,13 @@ package com.chesire.malime.core.models
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.chesire.malime.core.flags.Service
+import com.squareup.moshi.JsonClass
 
 /**
  * Data for a singular user entity.
  */
 @Entity
+@JsonClass(generateAdapter = true)
 data class UserModel(
     val userId: Int,
     val name: String,


### PR DESCRIPTION
Issues generating the correct adapters using Moshi 1.9.1, it looks like a couple of the models were missing the adapter generation line.
There was also an issue with 1.9.1 where it would fail to generate the correct model constructor if a nullable primitive was used (Int?), this should be fixed in https://github.com/square/moshi/pull/993/files, and hopefully be a part of 1.9.2 or 1.9.3.