### PR TITLE
fix: on tracking a new series, remove the progress bar on completion

### DIFF
--- a/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsAdapter.kt
+++ b/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsAdapter.kt
@@ -10,7 +10,7 @@ import com.chesire.malime.core.models.SeriesModel
  * Adapter to aid with displaying the search results.
  */
 class ResultsAdapter(
-    private val trackSeriesAction: (SeriesModel) -> Unit
+    private val resultsListener: ResultsListener
 ) : ListAdapter<SeriesModel, ResultsViewHolder>(SeriesModel.DiffCallback()) {
 
     /**
@@ -31,6 +31,6 @@ class ResultsAdapter(
     override fun onBindViewHolder(holder: ResultsViewHolder, position: Int) {
         val data = getItem(position)
         holder.bind(data, allSeries?.any { it.id == data.id } ?: false)
-        holder.bindAction(trackSeriesAction)
+        holder.bindListener(resultsListener)
     }
 }

--- a/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsFragment.kt
+++ b/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsFragment.kt
@@ -11,8 +11,12 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.app.search.R
+import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.core.viewmodel.ViewModelFactory
+import com.chesire.malime.server.Resource
+import com.google.android.material.snackbar.Snackbar
 import dagger.android.support.DaggerFragment
+import kotlinx.android.synthetic.main.fragment_results.resultsLayout
 import kotlinx.android.synthetic.main.fragment_results.resultsRecyclerView
 import javax.inject.Inject
 
@@ -20,14 +24,14 @@ import javax.inject.Inject
  * Displays the results of a search to the user, allowing them to select to track new series.
  */
 @LogLifecykle
-class ResultsFragment : DaggerFragment() {
+class ResultsFragment : DaggerFragment(), ResultsListener {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
     private val viewModel by lazy {
         ViewModelProvider(this, viewModelFactory).get<ResultsViewModel>()
     }
     private val args by navArgs<ResultsFragmentArgs>()
-    private val resultsAdapter = ResultsAdapter { viewModel.trackNewSeries(it) }
+    private val resultsAdapter = ResultsAdapter(this)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,7 +42,6 @@ class ResultsFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        observeTrackSeriesStatus()
         observeSeries()
         resultsAdapter.submitList(args.searchResults.toList())
         resultsRecyclerView.apply {
@@ -54,9 +57,16 @@ class ResultsFragment : DaggerFragment() {
         })
     }
 
-    private fun observeTrackSeriesStatus() {
-        viewModel.trackSeriesData.observe(viewLifecycleOwner, Observer {
-            resultsAdapter.notifyDataSetChanged()
-        })
+    override fun onTrack(model: SeriesModel, callback: () -> Unit) {
+        viewModel.trackNewSeries(model) {
+            if (it is Resource.Error) {
+                Snackbar.make(
+                    resultsLayout,
+                    getString(R.string.results_failure, model.title),
+                    Snackbar.LENGTH_LONG
+                ).show()
+            }
+            callback()
+        }
     }
 }

--- a/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsListener.kt
+++ b/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsListener.kt
@@ -1,0 +1,15 @@
+package com.chesire.malime.app.search.results
+
+import com.chesire.malime.core.models.SeriesModel
+
+/**
+ * Provides listener interface for interacting with the results list.
+ */
+interface ResultsListener {
+
+    /**
+     * Executed when the "Track" button has been pressed, the [callback] is then fired on
+     * completion.
+     */
+    fun onTrack(model: SeriesModel, callback: () -> Unit)
+}

--- a/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsViewHolder.kt
+++ b/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsViewHolder.kt
@@ -39,13 +39,23 @@ class ResultsViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutConta
     }
 
     /**
-     * Bind the [trackSeriesAction] to the [ResultsViewHolder] so click events can be collected.
+     * Bind the [ResultsListener] to the [ResultsViewHolder] so click events can be collected.
      */
-    fun bindAction(trackSeriesAction: (SeriesModel) -> Unit) {
+    fun bindListener(resultsListener: ResultsListener) {
         resultTrack.setOnClickListener {
-            resultTrack.hide()
-            resultProgressBar.show()
-            trackSeriesAction(seriesModel)
+            startTrackingSeries()
+            resultsListener.onTrack(seriesModel) {
+                finishTrackingSeries()
+            }
         }
+    }
+
+    private fun startTrackingSeries() {
+        resultTrack.hide()
+        resultProgressBar.show()
+    }
+
+    private fun finishTrackingSeries() {
+        resultProgressBar.hide()
     }
 }

--- a/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsViewModel.kt
+++ b/app-search/src/main/java/com/chesire/malime/app/search/results/ResultsViewModel.kt
@@ -1,13 +1,8 @@
 package com.chesire.malime.app.search.results
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.core.AuthCaster
-import com.chesire.malime.core.extensions.postError
-import com.chesire.malime.core.extensions.postSuccess
-import com.chesire.malime.core.flags.AsyncState
 import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.SeriesModel
@@ -24,32 +19,31 @@ class ResultsViewModel @Inject constructor(
     private val authCaster: AuthCaster
 ) : ViewModel() {
 
-    private val _trackSeriesData = MutableLiveData<AsyncState<SeriesModel, ResultsError>>()
-    val trackSeriesData: LiveData<AsyncState<SeriesModel, ResultsError>> = _trackSeriesData
     val series = seriesRepo.series
 
     /**
      * Adds [newSeries] to the list of tracked series.
      */
-    fun trackNewSeries(newSeries: SeriesModel) = viewModelScope.launch {
-        when (val result = when {
-            newSeries.type == SeriesType.Anime -> seriesRepo.addAnime(
+    fun trackNewSeries(
+        newSeries: SeriesModel,
+        callback: (Resource<SeriesModel>) -> Unit
+    ) = viewModelScope.launch {
+        val response = when (newSeries.type) {
+            SeriesType.Anime -> seriesRepo.addAnime(
                 newSeries.id,
                 UserSeriesStatus.Current
             )
-            newSeries.type == SeriesType.Manga -> seriesRepo.addManga(
+            SeriesType.Manga -> seriesRepo.addManga(
                 newSeries.id,
                 UserSeriesStatus.Current
             )
             else -> error("Unknown SeriesType: ${newSeries.type}")
-        }) {
-            is Resource.Error ->
-                if (result.code == Resource.Error.CouldNotRefresh) {
-                    authCaster.issueRefreshingToken()
-                } else {
-                    _trackSeriesData.postError(ResultsError.GenericError)
-                }
-            is Resource.Success -> _trackSeriesData.postSuccess(result.data)
+        }
+
+        if (response is Resource.Error && response.code == Resource.Error.CouldNotRefresh) {
+            authCaster.issueRefreshingToken()
+        } else {
+            callback(response)
         }
     }
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -93,7 +93,9 @@
     <string name="search_error_no_text">A series title must be provided</string>
     <string name="search_error_no_type_selected">A series type must be selected</string>
     <string name="search_error_no_series_found">No series could be found</string>
+
     <string name="results_track">Track</string>
+    <string name="results_failure">Failed to begin tracking series %s, please try again…</string>
 
     <string name="error_generic">An unknown error has occurred…</string>
 </resources>


### PR DESCRIPTION
The progress bar wasn't being removed as nothing was firing back to the viewholder to tell it to 
remove it. Add a callback to an listener that gets implemented to let the viewholder sort itself out