### PR TITLE
refactor: run some code cleanup

### DIFF
--- a/app-profile/src/main/java/com/chesire/malime/app/profile/ProfileViewModel.kt
+++ b/app-profile/src/main/java/com/chesire/malime/app/profile/ProfileViewModel.kt
@@ -16,8 +16,6 @@ class ProfileViewModel @Inject constructor(
     userRepository: UserRepository
 ) : ViewModel() {
     val user = userRepository.user
-    val anime = Transformations.map(seriesRepository.anime) { createSeriesProgress(it) }
-    val manga = Transformations.map(seriesRepository.manga) { createSeriesProgress(it) }
 
     private fun createSeriesProgress(items: List<SeriesModel>): SeriesProgress {
         val mapped = items.groupBy { it.userSeriesStatus }

--- a/app-profile/src/main/java/com/chesire/malime/app/profile/ProfileViewModel.kt
+++ b/app-profile/src/main/java/com/chesire/malime/app/profile/ProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.chesire.malime.app.profile
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import com.chesire.malime.account.UserRepository
+import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.series.SeriesRepository
@@ -16,6 +17,12 @@ class ProfileViewModel @Inject constructor(
     userRepository: UserRepository
 ) : ViewModel() {
     val user = userRepository.user
+    val anime = Transformations.map(seriesRepository.series) {
+        createSeriesProgress(it.filter { it.type == SeriesType.Anime })
+    }
+    val manga = Transformations.map(seriesRepository.series) {
+        createSeriesProgress(it.filter { it.type == SeriesType.Manga })
+    }
 
     private fun createSeriesProgress(items: List<SeriesModel>): SeriesProgress {
         val mapped = items.groupBy { it.userSeriesStatus }

--- a/app-profile/src/test/java/com/chesire/malime/app/profile/ProfileViewModelTests.kt
+++ b/app-profile/src/test/java/com/chesire/malime/app/profile/ProfileViewModelTests.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.chesire.malime.account.UserRepository
+import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.series.SeriesRepository
 import com.chesire.malime.testing.createSeriesModel
@@ -23,8 +24,7 @@ class ProfileViewModelTests {
     @Test
     fun `anime gets updated with seriesRepository anime series`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns MutableLiveData(listOf(createSeriesModel()))
-            every { manga } returns mockk()
+            every { series } returns MutableLiveData(listOf(createSeriesModel(seriesType = SeriesType.Anime)))
         }
         val mockUserRepo = mockk<UserRepository> {
             every { user } returns mockk()
@@ -42,8 +42,7 @@ class ProfileViewModelTests {
     @Test
     fun `manga gets updated with seriesRepository manga series`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(listOf(createSeriesModel()))
+            every { series } returns MutableLiveData(listOf(createSeriesModel(seriesType = SeriesType.Manga)))
         }
         val mockUserRepo = mockk<UserRepository> {
             every { user } returns mockk()
@@ -61,8 +60,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected total items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(
+            every { series } returns MutableLiveData(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Planned),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Planned),
@@ -79,16 +77,15 @@ class ProfileViewModelTests {
         }
 
         val classUnderTest = ProfileViewModel(mockSeriesRepo, mockUserRepo)
-        classUnderTest.manga.observeForever(mockObserver)
+        classUnderTest.anime.observeForever(mockObserver)
 
-        assertEquals("4", classUnderTest.manga.value?.total)
+        assertEquals("4", classUnderTest.anime.value?.total)
     }
 
     @Test
     fun `series has expected current items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(
+            every { series } returns MutableLiveData(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Current),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Planned),
@@ -105,16 +102,15 @@ class ProfileViewModelTests {
         }
 
         val classUnderTest = ProfileViewModel(mockSeriesRepo, mockUserRepo)
-        classUnderTest.manga.observeForever(mockObserver)
+        classUnderTest.anime.observeForever(mockObserver)
 
-        assertEquals("1", classUnderTest.manga.value?.current)
+        assertEquals("1", classUnderTest.anime.value?.current)
     }
 
     @Test
     fun `series has expected completed items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(
+            every { series } returns MutableLiveData(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Completed),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Completed),
@@ -131,16 +127,15 @@ class ProfileViewModelTests {
         }
 
         val classUnderTest = ProfileViewModel(mockSeriesRepo, mockUserRepo)
-        classUnderTest.manga.observeForever(mockObserver)
+        classUnderTest.anime.observeForever(mockObserver)
 
-        assertEquals("2", classUnderTest.manga.value?.completed)
+        assertEquals("2", classUnderTest.anime.value?.completed)
     }
 
     @Test
     fun `series has expected onHold items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(
+            every { series } returns MutableLiveData(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
@@ -157,16 +152,15 @@ class ProfileViewModelTests {
         }
 
         val classUnderTest = ProfileViewModel(mockSeriesRepo, mockUserRepo)
-        classUnderTest.manga.observeForever(mockObserver)
+        classUnderTest.anime.observeForever(mockObserver)
 
-        assertEquals("4", classUnderTest.manga.value?.onHold)
+        assertEquals("4", classUnderTest.anime.value?.onHold)
     }
 
     @Test
     fun `series has expected dropped items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(
+            every { series } returns MutableLiveData(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
@@ -183,16 +177,15 @@ class ProfileViewModelTests {
         }
 
         val classUnderTest = ProfileViewModel(mockSeriesRepo, mockUserRepo)
-        classUnderTest.manga.observeForever(mockObserver)
+        classUnderTest.anime.observeForever(mockObserver)
 
-        assertEquals("0", classUnderTest.manga.value?.dropped)
+        assertEquals("0", classUnderTest.anime.value?.dropped)
     }
 
     @Test
     fun `series has expected planned items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(
+            every { series } returns MutableLiveData(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
@@ -209,16 +202,15 @@ class ProfileViewModelTests {
         }
 
         val classUnderTest = ProfileViewModel(mockSeriesRepo, mockUserRepo)
-        classUnderTest.manga.observeForever(mockObserver)
+        classUnderTest.anime.observeForever(mockObserver)
 
-        assertEquals("1", classUnderTest.manga.value?.planned)
+        assertEquals("1", classUnderTest.anime.value?.planned)
     }
 
     @Test
     fun `series has expected unknown items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { anime } returns mockk()
-            every { manga } returns MutableLiveData(
+            every { series } returns MutableLiveData(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Unknown),
@@ -235,8 +227,8 @@ class ProfileViewModelTests {
         }
 
         val classUnderTest = ProfileViewModel(mockSeriesRepo, mockUserRepo)
-        classUnderTest.manga.observeForever(mockObserver)
+        classUnderTest.anime.observeForever(mockObserver)
 
-        assertEquals("2", classUnderTest.manga.value?.unknown)
+        assertEquals("2", classUnderTest.anime.value?.unknown)
     }
 }

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesAdapter.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesAdapter.kt
@@ -25,7 +25,7 @@ class SeriesAdapter(
     }
 
     private var container: RecyclerView? = null
-    private var completeList = mutableListOf<SeriesModel>()
+    private var completeList = listOf<SeriesModel>()
 
     /**
      * Execute when an item has been swiped away in the adapter.
@@ -44,7 +44,7 @@ class SeriesAdapter(
         }
     }
 
-    override fun submitList(list: MutableList<SeriesModel>?) {
+    override fun submitList(list: List<SeriesModel>?) {
         if (list == null) {
             Timber.w("Null list attempted to be passed to submitList")
             super.submitList(list)

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesInteractionListener.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesInteractionListener.kt
@@ -3,6 +3,9 @@ package com.chesire.malime.app.series.list
 import android.widget.ImageView
 import com.chesire.malime.core.models.SeriesModel
 
+/**
+ * Listener for events happening when interacting with the series list.
+ */
 interface SeriesInteractionListener {
     /**
      * Executed when a series has been selected.

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListDeleteError.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListDeleteError.kt
@@ -4,6 +4,5 @@ package com.chesire.malime.app.series.list
  * List of errors that can occur for failure to delete a series.
  */
 enum class SeriesListDeleteError {
-    None,
     DeletionFailure
 }

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListFragment.kt
@@ -38,7 +38,6 @@ import javax.inject.Inject
  * Provides a base fragment for the [AnimeFragment] & [MangaFragment] to inherit from, performing
  * most of the setup and interaction.
  */
-@Suppress("TooManyFunctions")
 abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
@@ -80,17 +79,16 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
             val itemTouchHelper = ItemTouchHelper(SwipeToDelete(seriesAdapter))
             itemTouchHelper.attachToRecyclerView(this)
         }
-        observeSeriesDeletion()
-    }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
         viewModel.series.observe(
             viewLifecycleOwner,
             Observer { series ->
-                newSeriesListProvided(series.filter { it.type == seriesType })
+                val newList = series.filter { it.type == seriesType }
+                Timber.d("New list provided, new count [${newList.count()}]")
+                seriesAdapter.submitList(newList)
             }
         )
+        observeSeriesDeletion()
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -166,13 +164,5 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
                 }.show()
             }
         })
-    }
-
-    /**
-     * Inform the adapter that a new series list has been provided.
-     */
-    protected fun newSeriesListProvided(newList: List<SeriesModel>) {
-        Timber.d("New list provided, new count [${newList.count()}]")
-        seriesAdapter.submitList(newList)
     }
 }

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListFragment.kt
@@ -158,6 +158,6 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
      */
     protected fun newSeriesListProvided(newList: List<SeriesModel>) {
         Timber.d("New list provided, new count [${newList.count()}]")
-        seriesAdapter.submitList(newList.toMutableList())
+        seriesAdapter.submitList(newList)
     }
 }

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListFragment.kt
@@ -23,6 +23,7 @@ import com.chesire.malime.app.series.list.manga.MangaFragment
 import com.chesire.malime.core.DialogHandler
 import com.chesire.malime.core.SharedPref
 import com.chesire.malime.core.flags.AsyncState
+import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.core.viewmodel.ViewModelFactory
 import com.chesire.malime.server.Resource
@@ -46,10 +47,14 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
     @Inject
     lateinit var sharedPref: SharedPref
 
-    protected val viewModel by lazy {
+    /**
+     * Flag for which type of series should be displayed in this fragment instance.
+     */
+    protected abstract val seriesType: SeriesType
+
+    private val viewModel by lazy {
         ViewModelProvider(this, viewModelFactory).get<SeriesListViewModel>()
     }
-
     private lateinit var seriesAdapter: SeriesAdapter
     private var seriesDetail: SeriesDetailSheetFragment? = null
 
@@ -76,6 +81,16 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
             itemTouchHelper.attachToRecyclerView(this)
         }
         observeSeriesDeletion()
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        viewModel.series.observe(
+            viewLifecycleOwner,
+            Observer { series ->
+                newSeriesListProvided(series.filter { it.type == seriesType })
+            }
+        )
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListViewModel.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListViewModel.kt
@@ -22,10 +22,9 @@ import kotlin.coroutines.CoroutineContext
  */
 class SeriesListViewModel @Inject constructor(
     private val repo: SeriesRepository,
-    private val authCaster: AuthCaster,
-    @IOContext private val ioContext: CoroutineContext
+    private val authCaster: AuthCaster
 ) : ViewModel() {
-    val series = liveData(ioContext) { emitSource(repo.series) }
+    val series = repo.series
     private val _deletionStatus = LiveEvent<AsyncState<SeriesModel, SeriesListDeleteError>>()
     val deletionStatus: LiveData<AsyncState<SeriesModel, SeriesListDeleteError>> = _deletionStatus
 

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListViewModel.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListViewModel.kt
@@ -2,10 +2,8 @@ package com.chesire.malime.app.series.list
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.core.AuthCaster
-import com.chesire.malime.core.IOContext
 import com.chesire.malime.core.extensions.postError
 import com.chesire.malime.core.flags.AsyncState
 import com.chesire.malime.core.flags.UserSeriesStatus
@@ -15,7 +13,6 @@ import com.chesire.malime.server.Resource
 import com.hadilq.liveevent.LiveEvent
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
 
 /**
  * ViewModel to use with the [SeriesListFragment], handles sending updates for a series.

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListViewModel.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesListViewModel.kt
@@ -2,8 +2,10 @@ package com.chesire.malime.app.series.list
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import com.chesire.malime.core.AuthCaster
+import com.chesire.malime.core.IOContext
 import com.chesire.malime.core.extensions.postError
 import com.chesire.malime.core.flags.AsyncState
 import com.chesire.malime.core.flags.UserSeriesStatus
@@ -13,17 +15,17 @@ import com.chesire.malime.server.Resource
 import com.hadilq.liveevent.LiveEvent
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 
 /**
  * ViewModel to use with the [SeriesListFragment], handles sending updates for a series.
  */
 class SeriesListViewModel @Inject constructor(
     private val repo: SeriesRepository,
-    private val authCaster: AuthCaster
+    private val authCaster: AuthCaster,
+    @IOContext private val ioContext: CoroutineContext
 ) : ViewModel() {
-    val animeSeries = repo.anime
-    val mangaSeries = repo.manga
-
+    val series = liveData(ioContext) { emitSource(repo.series) }
     private val _deletionStatus = LiveEvent<AsyncState<SeriesModel, SeriesListDeleteError>>()
     val deletionStatus: LiveData<AsyncState<SeriesModel, SeriesListDeleteError>> = _deletionStatus
 

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesViewHolder.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesViewHolder.kt
@@ -22,7 +22,7 @@ import kotlinx.android.synthetic.main.adapter_item_series.adapterItemSeriesTitle
  */
 class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
     private lateinit var seriesModel: SeriesModel
-    override val containerView: View?
+    override val containerView: View
         get() = itemView
 
     /**

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesViewHolder.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesViewHolder.kt
@@ -1,7 +1,6 @@
 package com.chesire.malime.app.series.list
 
 import android.view.View
-import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.chesire.malime.core.extensions.hide
@@ -38,7 +37,6 @@ class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContai
         adapterItemSeriesSubtype.text = model.subtype.name
         adapterItemSeriesProgress.text = "${model.progress} / ${model.totalLength}"
         adapterItemSeriesPlusOne.visibleIf(invisible = true) { model.progress < model.totalLength }
-        ViewCompat.setTransitionName(adapterItemSeriesImage, model.title)
     }
 
     /**

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/anime/AnimeFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/anime/AnimeFragment.kt
@@ -6,15 +6,10 @@ import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.app.series.list.SeriesListFragment
 import com.chesire.malime.core.flags.SeriesType
 
+/**
+ * Fragment to display the list of all [SeriesType.Anime] series.
+ */
 @LogLifecykle
 class AnimeFragment : SeriesListFragment() {
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel.series.observe(
-            viewLifecycleOwner,
-            Observer {
-                newSeriesListProvided(it.filter { it.type == SeriesType.Anime })
-            }
-        )
-    }
+    override val seriesType = SeriesType.Anime
 }

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/anime/AnimeFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/anime/AnimeFragment.kt
@@ -4,15 +4,16 @@ import android.os.Bundle
 import androidx.lifecycle.Observer
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.app.series.list.SeriesListFragment
+import com.chesire.malime.core.flags.SeriesType
 
 @LogLifecykle
 class AnimeFragment : SeriesListFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        viewModel.animeSeries.observe(
+        viewModel.series.observe(
             viewLifecycleOwner,
             Observer {
-                newSeriesListProvided(it)
+                newSeriesListProvided(it.filter { it.type == SeriesType.Anime })
             }
         )
     }

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/anime/AnimeFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/anime/AnimeFragment.kt
@@ -1,7 +1,5 @@
 package com.chesire.malime.app.series.list.anime
 
-import android.os.Bundle
-import androidx.lifecycle.Observer
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.app.series.list.SeriesListFragment
 import com.chesire.malime.core.flags.SeriesType

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/manga/MangaFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/manga/MangaFragment.kt
@@ -1,20 +1,13 @@
 package com.chesire.malime.app.series.list.manga
 
-import android.os.Bundle
-import androidx.lifecycle.Observer
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.app.series.list.SeriesListFragment
 import com.chesire.malime.core.flags.SeriesType
 
+/**
+ * Fragment to display the list of all [SeriesType.Manga] series.
+ */
 @LogLifecykle
 class MangaFragment : SeriesListFragment() {
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel.series.observe(
-            viewLifecycleOwner,
-            Observer {
-                newSeriesListProvided(it.filter { it.type == SeriesType.Manga })
-            }
-        )
-    }
+    override val seriesType = SeriesType.Manga
 }

--- a/app-series/src/main/java/com/chesire/malime/app/series/list/manga/MangaFragment.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/manga/MangaFragment.kt
@@ -4,15 +4,16 @@ import android.os.Bundle
 import androidx.lifecycle.Observer
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.malime.app.series.list.SeriesListFragment
+import com.chesire.malime.core.flags.SeriesType
 
 @LogLifecykle
 class MangaFragment : SeriesListFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        viewModel.mangaSeries.observe(
+        viewModel.series.observe(
             viewLifecycleOwner,
             Observer {
-                newSeriesListProvided(it)
+                newSeriesListProvided(it.filter { it.type == SeriesType.Manga })
             }
         )
     }

--- a/app-series/src/test/java/com/chesire/malime/app/series/list/SeriesListViewModelTests.kt
+++ b/app-series/src/test/java/com/chesire/malime/app/series/list/SeriesListViewModelTests.kt
@@ -35,8 +35,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 mockk()
             }
-            every { anime } returns mockk()
-            every { manga } returns mockk()
+            every { series } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
 
@@ -54,8 +53,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.CouldNotRefresh)
             }
-            every { anime } returns mockk()
-            every { manga } returns mockk()
+            every { series } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
@@ -76,8 +74,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.GenericError)
             }
-            every { anime } returns mockk()
-            every { manga } returns mockk()
+            every { series } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
 
@@ -96,8 +93,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Success(mockk())
             }
-            every { anime } returns mockk()
-            every { manga } returns mockk()
+            every { series } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
 
@@ -115,8 +111,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.CouldNotRefresh)
             }
-            every { anime } returns mockk()
-            every { manga } returns mockk()
+            every { series } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
@@ -136,8 +131,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.GenericError)
             }
-            every { anime } returns mockk()
-            every { manga } returns mockk()
+            every { series } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
         val mockObserver = mockk<Observer<AsyncState<SeriesModel, SeriesListDeleteError>>>() {

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -10,7 +10,7 @@
     <include app:graph="@navigation/search_nav_graph" />
     <include app:graph="@navigation/settings_nav_graph" />
 
-    <!-- OOB -->
+    <!-- Login -->
     <fragment
         android:id="@+id/detailsFragment"
         android:name="com.chesire.malime.flow.login.details.DetailsFragment"
@@ -31,35 +31,19 @@
             app:popUpTo="@+id/detailsFragment"
             app:popUpToInclusive="true" />
     </fragment>
-    <!-- End OOB -->
+    <!-- End Login -->
 
     <!-- Main -->
     <fragment
         android:id="@+id/animeFragment"
         android:name="com.chesire.malime.app.series.list.anime.AnimeFragment"
         android:label="@string/nav_anime"
-        tools:layout="@layout/fragment_series_list">
-        <action
-            android:id="@+id/toSearchFragment"
-            app:destination="@id/searchFragment"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
-    </fragment>
+        tools:layout="@layout/fragment_series_list" />
     <fragment
         android:id="@+id/mangaFragment"
         android:name="com.chesire.malime.app.series.list.manga.MangaFragment"
         android:label="@string/nav_manga"
-        tools:layout="@layout/fragment_series_list">
-        <action
-            android:id="@+id/toSearchFragment"
-            app:destination="@id/searchFragment"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
-    </fragment>
+        tools:layout="@layout/fragment_series_list" />
     <fragment
         android:id="@+id/timelineFragment"
         android:name="com.chesire.malime.app.timeline.TimelineFragment"
@@ -69,11 +53,7 @@
         android:id="@+id/profileFragment"
         android:name="com.chesire.malime.app.profile.ProfileFragment"
         android:label="@string/nav_profile"
-        tools:layout="@layout/fragment_profile">
-        <action
-            android:id="@+id/toSettings"
-            app:destination="@id/settingsFragment" />
-    </fragment>
+        tools:layout="@layout/fragment_profile" />
     <!-- End Main -->
 
     <!-- Global Actions -->

--- a/database/src/androidTest/java/com/chesire/malime/database/dao/SeriesDaoTests.kt
+++ b/database/src/androidTest/java/com/chesire/malime/database/dao/SeriesDaoTests.kt
@@ -130,7 +130,7 @@ class SeriesDaoTests {
             )
         )
         assertTrue(seriesDao.retrieve().count() == 6)
-        assertTrue(seriesDao.retrieve(SeriesType.Anime).count() == 3)
+        assertTrue(seriesDao.retrieve().filter { it.type == SeriesType.Anime }.count() == 3)
     }
 
     @Test

--- a/database/src/main/java/com/chesire/malime/database/dao/SeriesDao.kt
+++ b/database/src/main/java/com/chesire/malime/database/dao/SeriesDao.kt
@@ -33,10 +33,10 @@ interface SeriesDao {
     suspend fun insert(series: List<SeriesModel>)
 
     /**
-     * Provides an observable for all series.
+     * Provides an observable for all [SeriesModel].
      */
     @Query("SELECT * FROM seriesmodel")
-    fun observe(): LiveData<List<SeriesModel>>
+    fun series(): LiveData<List<SeriesModel>>
 
     /**
      * Updates the series [series].

--- a/database/src/main/java/com/chesire/malime/database/dao/SeriesDao.kt
+++ b/database/src/main/java/com/chesire/malime/database/dao/SeriesDao.kt
@@ -1,5 +1,6 @@
 package com.chesire.malime.database.dao
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
@@ -43,4 +44,12 @@ interface SeriesDao {
      */
     @Update
     suspend fun update(series: SeriesModel)
+
+    // This method only exists to allow easier testing of the SeriesDao.
+    /**
+     * Retrieves all series.
+     */
+    @VisibleForTesting
+    @Query("SELECT * FROM seriesmodel")
+    suspend fun retrieve(): List<SeriesModel>
 }

--- a/database/src/main/java/com/chesire/malime/database/dao/SeriesDao.kt
+++ b/database/src/main/java/com/chesire/malime/database/dao/SeriesDao.kt
@@ -7,7 +7,6 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.models.SeriesModel
 
 /**
@@ -38,24 +37,6 @@ interface SeriesDao {
      */
     @Query("SELECT * FROM seriesmodel")
     fun observe(): LiveData<List<SeriesModel>>
-
-    /**
-     * Provides an observable for the [type] of series.
-     */
-    @Query("SELECT * FROM seriesmodel WHERE type == :type")
-    fun observe(type: SeriesType): LiveData<List<SeriesModel>>
-
-    /**
-     * Retrieves all series.
-     */
-    @Query("SELECT * FROM seriesmodel")
-    suspend fun retrieve(): List<SeriesModel>
-
-    /**
-     * Retrieves all series of [type].
-     */
-    @Query("SELECT * FROM seriesmodel WHERE type == :type")
-    suspend fun retrieve(type: SeriesType): List<SeriesModel>
 
     /**
      * Updates the series [series].

--- a/series/src/main/java/com/chesire/malime/series/SeriesRepository.kt
+++ b/series/src/main/java/com/chesire/malime/series/SeriesRepository.kt
@@ -2,7 +2,6 @@ package com.chesire.malime.series
 
 import androidx.lifecycle.LiveData
 import com.chesire.malime.account.UserRepository
-import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.database.dao.SeriesDao

--- a/series/src/main/java/com/chesire/malime/series/SeriesRepository.kt
+++ b/series/src/main/java/com/chesire/malime/series/SeriesRepository.kt
@@ -20,7 +20,7 @@ class SeriesRepository(
     /**
      * Observable list of all the users series (Anime + Manga).
      */
-    val series: LiveData<List<SeriesModel>> = seriesDao.observe()
+    val series: LiveData<List<SeriesModel>> = seriesDao.series()
 
     /**
      * Adds the anime series with id [seriesId] to the users tracked list.

--- a/series/src/main/java/com/chesire/malime/series/SeriesRepository.kt
+++ b/series/src/main/java/com/chesire/malime/series/SeriesRepository.kt
@@ -19,22 +19,9 @@ class SeriesRepository(
     private val userRepository: UserRepository
 ) {
     /**
-     * Observable list of the users anime.
-     */
-    val anime: LiveData<List<SeriesModel>>
-        get() = seriesDao.observe(SeriesType.Anime)
-
-    /**
-     * Observable list of the users manga.
-     */
-    val manga: LiveData<List<SeriesModel>>
-        get() = seriesDao.observe(SeriesType.Manga)
-
-    /**
      * Observable list of all the users series (Anime + Manga).
      */
-    val series: LiveData<List<SeriesModel>>
-        get() = seriesDao.observe()
+    val series: LiveData<List<SeriesModel>> = seriesDao.observe()
 
     /**
      * Adds the anime series with id [seriesId] to the users tracked list.

--- a/series/src/test/java/com/chesire/malime/series/SeriesRepositoryTests.kt
+++ b/series/src/test/java/com/chesire/malime/series/SeriesRepositoryTests.kt
@@ -45,6 +45,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
@@ -64,6 +65,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
@@ -83,6 +85,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Error<SeriesModel>("Error")
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
@@ -102,6 +105,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
@@ -121,6 +125,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
@@ -140,6 +145,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Error<SeriesModel>("Error")
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
@@ -161,6 +167,7 @@ class SeriesRepositoryTests {
         }
         val mockDao = mockk<SeriesDao> {
             coEvery { delete(any()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns Resource.Success(Any())
@@ -180,6 +187,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success(Any())
         val mockDao = mockk<SeriesDao> {
             coEvery { delete(any()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns expected
@@ -201,6 +209,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Error<Any>("")
         val mockDao = mockk<SeriesDao> {
             coEvery { delete(any()) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns expected
@@ -222,6 +231,7 @@ class SeriesRepositoryTests {
         val expected = mockk<SeriesModel>()
         val mockDao = mockk<SeriesDao> {
             coEvery { update(expected) } just Runs
+            every { series() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery {
@@ -240,7 +250,9 @@ class SeriesRepositoryTests {
 
     @Test
     fun `updateSeries on failure returns failure`() = runBlocking {
-        val mockDao = mockk<SeriesDao>()
+        val mockDao = mockk<SeriesDao> {
+            every { series() } returns mockk()
+        }
         val mockApi = mockk<LibraryApi> {
             coEvery {
                 update(0, 0, UserSeriesStatus.Current)

--- a/series/src/test/java/com/chesire/malime/series/SeriesRepositoryTests.kt
+++ b/series/src/test/java/com/chesire/malime/series/SeriesRepositoryTests.kt
@@ -3,7 +3,6 @@ package com.chesire.malime.series
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.chesire.malime.account.UserRepository
-import com.chesire.malime.core.flags.SeriesType
 import com.chesire.malime.core.flags.UserSeriesStatus
 import com.chesire.malime.core.models.SeriesModel
 import com.chesire.malime.database.dao.SeriesDao
@@ -28,37 +27,9 @@ class SeriesRepositoryTests {
     val rule = InstantTaskExecutorRule()
 
     @Test
-    fun `anime observes the dao anime series`() {
-        val mockDao = mockk<SeriesDao> {
-            every { observe(SeriesType.Anime) } returns mockk { every { observeForever(any()) } just Runs }
-        }
-        val mockApi = mockk<LibraryApi>()
-        val mockUser = mockk<UserRepository>()
-
-        val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
-        classUnderTest.anime.observeForever(mockk<Observer<List<SeriesModel>>>())
-
-        verify { mockDao.observe(SeriesType.Anime) }
-    }
-
-    @Test
-    fun `manga observes the dao manga series`() {
-        val mockDao = mockk<SeriesDao> {
-            every { observe(SeriesType.Manga) } returns mockk { every { observeForever(any()) } just Runs }
-        }
-        val mockApi = mockk<LibraryApi>()
-        val mockUser = mockk<UserRepository>()
-
-        val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
-        classUnderTest.manga.observeForever(mockk<Observer<List<SeriesModel>>>())
-
-        verify { mockDao.observe(SeriesType.Manga) }
-    }
-
-    @Test
     fun `series observes all the dao series`() {
         val mockDao = mockk<SeriesDao> {
-            every { observe() } returns mockk { every { observeForever(any()) } just Runs }
+            every { series() } returns mockk { every { observeForever(any()) } just Runs }
         }
         val mockApi = mockk<LibraryApi>()
         val mockUser = mockk<UserRepository>()
@@ -66,7 +37,7 @@ class SeriesRepositoryTests {
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
         classUnderTest.series.observeForever(mockk<Observer<List<SeriesModel>>>())
 
-        verify { mockDao.observe() }
+        verify { mockDao.series() }
     }
 
     @Test


### PR DESCRIPTION
Originally this was to try and remove the stutter when changing between the anime and manga screens, but it looks like that is happening as a result of loading all the items into the adapter. So making a PR with a bunch of changes that were made to test this, and generally code cleanup on various parts of the application.