### PR TITLE
fix: recyclerview leaking in serieslist

### DIFF
--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesAdapter.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesAdapter.kt
@@ -59,6 +59,11 @@ class SeriesAdapter(
         container = recyclerView
     }
 
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        container = null
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SeriesViewHolder {
         return SeriesViewHolder(
             LayoutInflater.from(parent.context).inflate(R.layout.adapter_item_series, parent, false)


### PR DESCRIPTION
A reference to the recyclerview was being held in the SeriesAdapter but never removed, add override
to onDetachedFromRecyclerView so it can be nulled out and GCed