### PR TITLE
chore: add commitizen to the setup of the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
+    "cz-conventional-changelog": "^3.0.2",
     "husky": "^3.0.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
Add the commitizen config development dependency so anybody else using the repo should get the same commitizen rules to use