### PR TITLE
fix: cannot +1 progress of some series items

### DIFF
--- a/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesViewHolder.kt
+++ b/app-series/src/main/java/com/chesire/malime/app/series/list/SeriesViewHolder.kt
@@ -41,7 +41,9 @@ class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContai
             model.progress.toString(),
             if (model.lengthKnown) model.totalLength else '-'
         )
-        adapterItemSeriesPlusOne.visibleIf(invisible = true) { model.progress < model.totalLength }
+        adapterItemSeriesPlusOne.visibleIf(invisible = true) {
+            !model.lengthKnown || model.progress < model.totalLength
+        }
     }
 
     /**


### PR DESCRIPTION
Series items which had an indeterminate length would not show the +1 icon on them, update the lambda
to determine if it should be visible