### PR TITLE
refactor: hide the discover flow until it is ready to be integrated

### DIFF
--- a/app/src/main/res/menu/menu_navigation.xml
+++ b/app/src/main/res/menu/menu_navigation.xml
@@ -20,10 +20,6 @@
             android:id="@+id/search_nav_graph"
             android:icon="@drawable/ic_search"
             android:title="@string/nav_search" />
-        <item
-            android:id="@+id/discover_nav_graph"
-            android:icon="@drawable/ic_whatshot"
-            android:title="@string/nav_discover" />
     </group>
 
     <group


### PR DESCRIPTION
Discover is still not finished, in order to get the application at a decent stage to use it, hide
the discover section for now, and it can be added in a later version